### PR TITLE
Simplifying using rasa

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN bash entrypoint.sh download spacy en
 #Uncomment this line using mitie and sklearn (and comment the lines of the other models)
 #COPY config_mitie_sklearn.json /app/config.json 
 
-
+RUN ls /app
 
 EXPOSE 5000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,23 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
   pip install -r "${RASA_NLU_HOME}/requirements.txt"
 
-RUN python setup.py install
+RUN python setup.py install 
 
-RUN ls /app
+
+#Uncomment these lines for using spacy (and comment the lines of the other models)
+COPY config_spacy.json /app/config.json 
+#Uncomment the language you want to use for spacy
+RUN bash entrypoint.sh download spacy en
+#RUN bash entrypoint.sh download spacy de
+
+#Uncomment these lines for using mittie (and comment the lines of the other models)
+#COPY config_mitie.json /app/config.json
+#RUN bash entrypoint.sh download mitie
+
+#Uncomment this line using mitie and sklearn (and comment the lines of the other models)
+#COPY config_mitie_sklearn.json /app/config.json 
+
+
 
 EXPOSE 5000
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ If you want to use another model read the Dockerfile, comment spacy english mode
 
 Execute as root:
 ```
-chmod +x ./manage_container
 ./manage_container build
 ```
 ##### 2. Training system

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ curl 'http://localhost:5000/parse?q=hello'
 ```
 
 #### B.2 Install with Docker automatically
+Automatically installation uses spacy english model and configure trained model as default if there is only one trained model.
+If you want to use another model read the Dockerfile, comment spacy english model lines and uncomment the lines for your selected model.
 
 ##### 1. Create container
 
@@ -87,6 +89,10 @@ Try it with any phrase suitable for your intents, using %20 as spaces in the URL
 ```
 curl 'http://localhost:5000/parse?q=hello%20machine'
 ```
+
+##### 5. Change configuration
+
+
 
 ### C. (Experimental) Deploying to Docker Cloud
 [![Deploy to Docker Cloud](https://files.cloud.docker.com/images/deploy-to-dockercloud.svg)](https://cloud.docker.com/stack/deploy/)

--- a/README.md
+++ b/README.md
@@ -43,21 +43,49 @@ curl 'http://localhost:5000/parse?q=hello'
 ### B. Install with Docker
 Before you start, ensure you have the latest version of docker engine on your machine. You can check if you have docker installed by typing ```docker -v``` in your terminal.
 
-#### 1. Build the image:
+#### B.1 Install with Docker manually
+##### 1. Build the image:
 ```
 docker build -t rasa_nlu .
 ``` 
 
-#### 2. Start the web server:
+##### 2. Start the web server:
 ```
 docker run -p 5000:5000 rasa_nlu start
 ```
 
 Caveat for Docker for Windows users: please share your C: in docker settings, and add ```-v C:\path\to\rasa_nlu:/app``` to your docker run commands for download and training to work correctly.
 
-#### 3. Test it!
+##### 3. Test it!
 ```
 curl 'http://localhost:5000/parse?q=hello'
+```
+
+#### B.2 Install with Docker automatically
+
+##### 1. Create container
+
+Execute as root:
+```
+chmod +x ./manage_container
+./manage_container build
+```
+##### 2. Training system
+Create your training intents and save it as trainingFile.json, then execute:
+```
+curl -XPOST localhost:5000/train -d @trainingFile.json
+```
+
+##### 3. Load your model
+Rasa must be restarted in order to load new models, so execute as root:
+```
+./manage_container reload
+```
+
+##### 4. Test it!
+Try it with any phrase suitable for your intents, using %20 as spaces in the URL. For example, for "hello machine" phrase use:
+```
+curl 'http://localhost:5000/parse?q=hello%20machine'
 ```
 
 ### C. (Experimental) Deploying to Docker Cloud

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,8 +39,36 @@ function download_package {
     esac
 }
 
+# If there is only a model, set it as default model
+function set_default_model {
+   if [ -d "/app/models" ]
+     echo "Models directory exists"
+     then
+     if [ ! -d "/app/models/default" ]
+       then
+       echo "Default model doesn't exist"
+       if [ "x1" == x`ls -ld /app/models/* | wc -l` ]
+          then
+          echo "Renaming existing model to default"
+          mv `ls -d /app/models/*` /app/models/default
+          if [ -d "/app/models/default" ]
+          then
+              echo "Model renamed to default"
+          else
+              echo "Model couldn't be renamed to default"
+          fi
+       else
+          echo "There are no models or more than one"
+       fi
+     fi
+   fi
+}
+
+
+
 case ${1} in
     start)
+        set_default_model
         exec python -m rasa_nlu.server "${@:2}" 
         ;;
     run)

--- a/manage_container
+++ b/manage_container
@@ -13,6 +13,6 @@ case $1 in
         ;;
     reload)
         docker stop rasa_engine
-        docker start asa_engine
+        docker start rasa_engine
         ;;
 esac

--- a/manage_container
+++ b/manage_container
@@ -1,0 +1,18 @@
+#/bin/bash
+
+case $1 in 
+    build)
+        docker build -t rasa .
+        docker run --name rasa_engine -p 5000:5000 rasa start
+        ;;
+    start)
+        docker start rasa_engine
+        ;;
+    stop)
+        docker stop rasa_engine
+        ;;
+    reload)
+        docker stop rasa_engine
+        docker start asa_engine
+        ;;
+esac

--- a/manage_container
+++ b/manage_container
@@ -15,4 +15,6 @@ case $1 in
         docker stop rasa_engine
         docker start rasa_engine
         ;;
+    *)
+      echo "Usage: ./manage_container build|start|stop|reload"
 esac


### PR DESCRIPTION
**Proposed changes**:
- Changed Dockerfile for enabling a model just after container is built
- Changed entrypoint for setting an unique existing model as default model (rasa look for a default model, but it is not set after training)
- Added script for managing rasa container. It avoids people needs to know docker in order to use rasa. Rasa needs to be rebooted in order to load previous trained models. This script makes this easier for people don't know the difference between docker build, run, start and stop.

After those changes you have to execute "./manage_container build", send the training json using curl and execute "./manage_container restart" for getting a working rasa.