### PR TITLE
support reference_time for duckling

### DIFF
--- a/_pytest/test_components.py
+++ b/_pytest/test_components.py
@@ -85,7 +85,7 @@ def test_all_arguments_can_be_satisfied_during_parse(component_class, default_co
 
     # All available context arguments that will ever be generated during parse
     component = component_builder.create_component(component_class.name, default_config)
-    context_arguments = {"text": None, "ref_time": ""}
+    context_arguments = {"text": None, "time": None}
     for clz in registry.component_classes:
         for ctx_arg in clz.context_provides.get("pipeline_init", []):
             context_arguments[ctx_arg] = None

--- a/_pytest/test_components.py
+++ b/_pytest/test_components.py
@@ -85,7 +85,7 @@ def test_all_arguments_can_be_satisfied_during_parse(component_class, default_co
 
     # All available context arguments that will ever be generated during parse
     component = component_builder.create_component(component_class.name, default_config)
-    context_arguments = {"text": None}
+    context_arguments = {"text": None, "ref_time": ""}
     for clz in registry.component_classes:
         for ctx_arg in clz.context_provides.get("pipeline_init", []):
             context_arguments[ctx_arg] = None

--- a/_pytest/test_emulators.py
+++ b/_pytest/test_emulators.py
@@ -8,7 +8,7 @@ def test_luis_request():
     from rasa_nlu.emulators.luis import LUISEmulator
     em = LUISEmulator()
     norm = em.normalise_request_json({"q": ["arb text"]})
-    assert norm == {"text": "arb text", "model": "default"}
+    assert norm == {"text": "arb text", "model": "default", "time": None}
 
 
 def test_luis_response():
@@ -78,7 +78,7 @@ def test_wit_request():
     from rasa_nlu.emulators.wit import WitEmulator
     em = WitEmulator()
     norm = em.normalise_request_json({"q": ["arb text"]})
-    assert norm == {"text": "arb text", "model": "default"}
+    assert norm == {"text": "arb text", "model": "default", "time": None}
 
 
 def test_wit_response():
@@ -109,7 +109,7 @@ def test_api_request():
     from rasa_nlu.emulators.api import ApiEmulator
     em = ApiEmulator()
     norm = em.normalise_request_json({"q": ["arb text"]})
-    assert norm == {"text": "arb text", "model": "default"}
+    assert norm == {"text": "arb text", "model": "default", "time": None}
 
 
 def test_api_response():
@@ -159,10 +159,10 @@ def test_dummy_request():
     from rasa_nlu.emulators import NoEmulator
     em = NoEmulator()
     norm = em.normalise_request_json({"q": ["arb text"]})
-    assert norm == {"text": "arb text", "model": "default"}
+    assert norm == {"text": "arb text", "model": "default", "time": None}
 
-    norm = em.normalise_request_json({"q": ["arb text"], "model": "specific"})
-    assert norm == {"text": "arb text", "model": "specific"}
+    norm = em.normalise_request_json({"q": ["arb text"], "model": "specific", "time": "1499279161658"})
+    assert norm == {"text": "arb text", "model": "specific", "time": "1499279161658"}
 
 
 def test_dummy_response():

--- a/_pytest/test_interpreter.py
+++ b/_pytest/test_interpreter.py
@@ -35,7 +35,7 @@ def test_samples(pipeline_template, component_builder):
     ]
 
     for text, gold in samples:
-        result = interpreter.parse(text)
+        result = interpreter.parse(text, time=None)
         assert result['text'] == text, \
             "Wrong text for sample '{}'".format(text)
         assert result['intent']['name'] in available_intents, \

--- a/_pytest/test_train.py
+++ b/_pytest/test_train.py
@@ -26,7 +26,7 @@ def test_train_model(pipeline_template, component_builder):
     assert trained.pipeline
     loaded = utilities.load_interpreter_for_model(_config, persisted_path, component_builder)
     assert loaded.pipeline
-    assert loaded.parse("hello") is not None
+    assert loaded.parse("hello", time=None) is not None
 
 
 @slowtest
@@ -37,7 +37,7 @@ def test_train_model_noents(component_builder):
     assert trained.pipeline
     loaded = utilities.load_interpreter_for_model(_config, persisted_path, component_builder)
     assert loaded.pipeline
-    assert loaded.parse("hello") is not None
+    assert loaded.parse("hello", time=None) is not None
 
 
 @slowtest
@@ -48,7 +48,7 @@ def test_train_model_multithread(component_builder):
     assert trained.pipeline
     loaded = utilities.load_interpreter_for_model(_config, persisted_path, component_builder)
     assert loaded.pipeline
-    assert loaded.parse("hello") is not None
+    assert loaded.parse("hello", time=None) is not None
 
 
 def test_train_model_empty_pipeline(component_builder):
@@ -80,7 +80,7 @@ def test_load_and_persist_without_train(component_builder):
     persisted_path = trainer.persist(_config['path'], persistor, model_name=_config['name'])
     loaded = utilities.load_interpreter_for_model(_config, persisted_path, component_builder)
     assert loaded.pipeline
-    assert loaded.parse("hello") is not None
+    assert loaded.parse("hello", time=None) is not None
 
 
 def test_train_with_empty_data(component_builder):
@@ -91,4 +91,4 @@ def test_train_with_empty_data(component_builder):
     persisted_path = trainer.persist(_config['path'], persistor, model_name=_config['name'])
     loaded = utilities.load_interpreter_for_model(_config, persisted_path, component_builder)
     assert loaded.pipeline
-    assert loaded.parse("hello") is not None
+    assert loaded.parse("hello", time=None) is not None

--- a/rasa_nlu/components.py
+++ b/rasa_nlu/components.py
@@ -149,7 +149,7 @@ def validate_arguments(pipeline, config, allow_empty_pipeline=False):
             raise Exception("Failed to validate at component '{}'. {}".format(component.name, e))
 
     # Reset context to test processing phase and prepare for training phase
-    context = {"entities": [], "text": None}
+    context = {"entities": [], "text": None, "ref_time": ""}
     context.update(after_init_context)
 
     for component in pipeline:

--- a/rasa_nlu/components.py
+++ b/rasa_nlu/components.py
@@ -149,7 +149,7 @@ def validate_arguments(pipeline, config, allow_empty_pipeline=False):
             raise Exception("Failed to validate at component '{}'. {}".format(component.name, e))
 
     # Reset context to test processing phase and prepare for training phase
-    context = {"entities": [], "text": None, "ref_time": ""}
+    context = {"entities": [], "text": None, "time": None}
     context.update(after_init_context)
 
     for component in pipeline:

--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -175,7 +175,7 @@ class DataRouter(object):
                 raise InvalidModelError("No model found with alias '{}'. Error: {}".format(alias, e))
 
         model = self.model_store[alias]
-        response = model.parse(data['text'])
+        response = model.parse(data['text'], data['ref_time'])
         if self.responses:
             self.responses.info(json.dumps(response, sort_keys=True))
         return self.format_response(response)

--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -175,7 +175,7 @@ class DataRouter(object):
                 raise InvalidModelError("No model found with alias '{}'. Error: {}".format(alias, e))
 
         model = self.model_store[alias]
-        response = model.parse(data['text'], data['ref_time'])
+        response = model.parse(data['text'], data.get('time', None))
         if self.responses:
             self.responses.info(json.dumps(response, sort_keys=True))
         return self.format_response(response)

--- a/rasa_nlu/emulators/__init__.py
+++ b/rasa_nlu/emulators/__init__.py
@@ -26,6 +26,7 @@ class NoEmulator(object):
             _data["model"] = data["model"][0]
         else:
             _data["model"] = data["model"]
+        _data['ref_time'] = data["ref_time"] if "ref_time" in data else ""
         return _data
 
     def normalise_response_json(self, data):

--- a/rasa_nlu/emulators/__init__.py
+++ b/rasa_nlu/emulators/__init__.py
@@ -26,7 +26,7 @@ class NoEmulator(object):
             _data["model"] = data["model"][0]
         else:
             _data["model"] = data["model"]
-        _data['ref_time'] = data["ref_time"] if "ref_time" in data else ""
+        _data['time'] = data["time"] if "time" in data else None
         return _data
 
     def normalise_response_json(self, data):

--- a/rasa_nlu/extractors/duckling_extractor.py
+++ b/rasa_nlu/extractors/duckling_extractor.py
@@ -80,16 +80,6 @@ class DucklingExtractor(EntityExtractor):
 
         return cls.name + "-" + model_metadata.language
 
-    def pipeline_init(self, language):
-        # type: (Text, Text) -> None
-        from duckling import DucklingWrapper
-
-        if self.duckling is None:
-            try:
-                self.duckling = DucklingWrapper(language=language)  # languages in duckling are eg "de$core"
-            except ValueError as e:     # pragma: no cover
-                raise Exception("Duckling error. {}".format(e))
-
     def process(self, text, entities, time):
         # type: (Text, List[Dict[Text, Any]]) -> Dict[Text, Any]
 

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -235,7 +235,7 @@ class Interpreter(object):
         self.meta = meta
         self.output_attributes = [output for component in pipeline for output in component.output_provides]
 
-    def parse(self, text):
+    def parse(self, text, ref_time=""):
         # type: (Text) -> Dict[Text, Any]
         """Parse the input text, classify it and return an object containing its intent and entities."""
 
@@ -250,6 +250,7 @@ class Interpreter(object):
 
         current_context.update({
             "text": text,
+            "ref_time": ref_time
         })
 
         for component in self.pipeline:

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -235,7 +235,7 @@ class Interpreter(object):
         self.meta = meta
         self.output_attributes = [output for component in pipeline for output in component.output_provides]
 
-    def parse(self, text, ref_time=""):
+    def parse(self, text, time):
         # type: (Text) -> Dict[Text, Any]
         """Parse the input text, classify it and return an object containing its intent and entities."""
 
@@ -250,7 +250,7 @@ class Interpreter(object):
 
         current_context.update({
             "text": text,
-            "ref_time": ref_time
+            "time": time
         })
 
         for component in self.pipeline:


### PR DESCRIPTION
**Proposed changes**:
Duckling module also supports passing a context using reference_time argument. We can pass a string in RFC3339 format (Eg: '2008-09-08T22:47:31-07:00').

Example: Parsing "tomorrow" with reference_time set to `2008-09-08T20:30:00-07:00` gives back 
`2008-09-09T00:00:00.000-07:00`

Since Rasa supports duckling in the pipeline, I think this will be a useful addition.

**Status**:
- [ ] ready for code review
- [ ] there are tests for the functionality
- [ ] documentation updated
- [ ] changelog updated
