### PR TITLE
Replaced flask http server with klein

### DIFF
--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -45,7 +45,7 @@ def requires_auth(f):
     def decorated(*args, **kwargs):
         self = args[0]
         request = args[1]
-        token = request.args.get('token', '')[0]
+        token = request.args.get('token', [''])[0]
         if self.data_router.token is None or token == self.data_router.token:
             return f(*args, **kwargs)
         return "unauthorized", 401

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e .
 gevent==1.2.1
-flask==0.12
+klein
 boto3==1.4.4
 typing==3.5.3.0
 future==0.16.0


### PR DESCRIPTION
This is a working proposal. I struggled a lot with the actual implementation just by trying to add a freshly trained model  to the config's `server_model_dirs` variable after a call to the `/train` http endpoint. Indeed it escalated quickly into a multiprocessing management hell whereas Klein non blocking request handling model would have been far easier to use.

I didn't have time to write some asynchronous request handling using Twisted Deferred objects, so this is just a basic replacement.

What do you think?

**Proposed changes**:
- Replaced the Flask http server with Klein

**Status**:
- [X] ready for code review
- [ ] there are tests for the functionality
- [ ] documentation updated
- [ ] changelog updated
