### PR TITLE
Log problematic sentences

### DIFF
--- a/docs/closeloop.rst
+++ b/docs/closeloop.rst
@@ -8,3 +8,17 @@ By default log files are placed in ``logs/``. The files in this directory contai
 You can fix any incorrect predictions and add them to your training set to improve your parser.
 After adding these to your training data, but before retraining your model, it is strongly recommended that you use the
 visualizer to spot any errors, see :ref:`Visualizing training data <visualizing-the-training-data>`.
+
+Low confidence prediction logging
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+You can choose to automatically log problematic predictions to be later processed in the Rasa NLU Trainer.
+To use this logger, create a ``trainer_conf.json`` at the root of your Rasa installation folder:
+.. code-block:: json
+
+    {
+      "source": "data/test/wit_converted_to_rasa.json", // the training file path
+      "pending_file": "data/test/wit_converted_to_rasa-pending.json", // the file in which Rasa store the pending strings
+      "threshold": 0.7 // the confidence limit, under that limit the string will be saved
+    }
+
+You will then be able to import those strings from the Rasa NLU Trainer using the "import pendings" button.

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -17,6 +17,8 @@ from rasa_nlu.config import RasaNLUConfig
 from rasa_nlu.data_router import DataRouter, InvalidModelError
 from rasa_nlu.version import __version__
 
+from rasa_nlu.utils.trainer_utils import TrainerUtils
+
 logger = logging.getLogger(__name__)
 
 
@@ -72,6 +74,7 @@ def create_app(config, component_builder=None):
             try:
                 data = current_app.data_router.extract(request_params)
                 response = current_app.data_router.parse(data)
+                trainer.process_response(response)
                 return jsonify(response)
             except InvalidModelError as e:
                 return jsonify({"error": "{}".format(e)}), 404
@@ -105,6 +108,7 @@ def create_app(config, component_builder=None):
     logging.basicConfig(filename=config['log_file'], level=config['log_level'])
     logging.captureWarnings(True)
     logger.info("Configuration: " + config.view())
+    trainer = TrainerUtils(logger)
 
     logger.debug("Creating a new data router")
     rasa_nlu_app.data_router = DataRouter(config, component_builder)

--- a/rasa_nlu/utils/trainer_utils.py
+++ b/rasa_nlu/utils/trainer_utils.py
@@ -1,0 +1,54 @@
+import json, os.path, hashlib
+
+class TrainerUtils():
+    def __init__(self, logger):
+      self.config = False
+      self.logger = logger
+      
+      self.load_config()
+      self.check_pending_data_file()
+
+    def load_config(self):
+      config_file_path = os.path.dirname(__file__) + '/../../trainer_conf.json'
+
+      if os.path.exists(config_file_path) :
+        with open(config_file_path) as config_file:
+          config = json.load(config_file)
+      else :
+        self.logger.info("Cannot find trainer_conf.json in " + config_file_path + ", thus the trainer util won't be used")
+
+      self.config = config
+
+    def check_pending_data_file(self):
+      if not self.config :
+        return
+      
+      pending_file_path =  os.path.dirname(__file__) + '/../../' + self.config['pending_file']
+      if not os.path.exists(pending_file_path) :
+        self.logger.info("Pending string file doesn't exists")
+        with open(pending_file_path,"w") as pending_file:
+          pending_file.write("{}")
+          self.logger.info("Pending string file created")
+
+    def process_response(self, response):
+      if not self.config :
+        return
+
+      if not response['intent'] or response['intent']['confidence'] < self.config['threshold']:
+        string_hash = hashlib.md5(response['text']).hexdigest()
+
+        pending_file_path =  os.path.dirname(__file__) + '/../../' + self.config['pending_file']
+        with open(pending_file_path,"r+") as pending_file:
+          try :
+            pending_file_data = json.load(pending_file)
+          except ValueError:
+            pending_file_data = {}
+          
+          if string_hash not in pending_file_data :
+            pending_file_data.setdefault(string_hash, response['text'])
+            pending_file.seek(0)
+            pending_file.write(json.dumps(pending_file_data))
+            pending_file.flush()
+            self.logger.info("Pending string added")
+
+    

--- a/trainer_conf.json
+++ b/trainer_conf.json
@@ -1,5 +1,5 @@
 {
-  "source": "data/test/wit_converted_to_rasa.json.json",
-  "pending_file": "data/test/wit_converted_to_rasa.json_pending.json",
+  "source": "data/test/wit_converted_to_rasa.json",
+  "pending_file": "data/test/wit_converted_to_rasa-pending.json",
   "threshold": 0.7
 }

--- a/trainer_conf.json
+++ b/trainer_conf.json
@@ -1,0 +1,5 @@
+{
+  "source": "data/test/wit_converted_to_rasa.json.json",
+  "pending_file": "data/test/wit_converted_to_rasa.json_pending.json",
+  "threshold": 0.7
+}


### PR DESCRIPTION
Automatically log problematic sentences as pending for the trainer web interface, PR on rasa-nlu-trainer to import those pending strings

**Proposed changes**:
- Added a processor on the response
- Based on a config file, compares the threshold defined with the response confidence and if needed log the string to a JSON file defined in the config file
- The extracted strings can be imported in the Rasa-nlu-trainer

**Status**:
- [x] ready for code review
- [ ] there are tests for the functionality
- [x] documentation updated
- [ ] changelog updated
