### PR TITLE
Fix typo in Doc: "classifcation" to "classification"

### DIFF
--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -181,7 +181,7 @@ intent_entity_featurizer_regex
 :Description:
     During training, the regex intent featurizer creates a list of `regular expressions` defined in the training data format.
     If an expression is found in the input, a feature will be set, that will later be fed into intent classifier / entity
-    extractor to simplify classifcation (assuming the classifier has learned during the training phase, that this set
+    extractor to simplify classification (assuming the classifier has learned during the training phase, that this set
     feature indicates a certain intent). Regex features for entity extraction are currently only supported by the
     ``ner_crf`` component!
 


### PR DESCRIPTION
**Proposed changes**:
- ...

**Status**:
- [x] ready for code review
- [ ] there are tests for the functionality
- [x] documentation updated
- [ ] changelog updated
