### PR TITLE
Fix server training encoding

### DIFF
--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -217,7 +217,7 @@ class DataRouter(object):
 
     def start_train_process(self, data, config_values):
         f = tempfile.NamedTemporaryFile("w+", suffix="_training_data.json", delete=False)
-        f.write(data)
+        f.write(data.encode("utf-8"))
         f.close()
         # TODO: fix config handling
         _config = self.config.as_dict()

--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -14,6 +14,7 @@ import io
 
 from builtins import object
 from typing import Text
+from future.utils import PY3
 
 from concurrent.futures import ProcessPoolExecutor as ProcessPool
 from twisted.internet.defer import Deferred, maybeDeferred
@@ -216,8 +217,12 @@ class DataRouter(object):
         }
 
     def start_train_process(self, data, config_values):
-        f = tempfile.NamedTemporaryFile("w+", suffix="_training_data.json", delete=False)
-        f.write(data.encode("utf-8"))
+        if PY3:
+            f = tempfile.NamedTemporaryFile("w+", suffix="_training_data.json", delete=False, encoding="utf-8")
+            f.write(data)
+        else:
+            f = tempfile.NamedTemporaryFile("w+", suffix="_training_data.json", delete=False)
+            f.write(data.encode("utf-8"))
         f.close()
         # TODO: fix config handling
         _config = self.config.as_dict()


### PR DESCRIPTION
Hey there,

**Proposed changes**:
When I use the `/train` route on your server to re-train my models, I get an encoding error (`{"error": "'ascii' codec can't encode character u'\\u2019' in position 29892: ordinal not in range(128)"}`). This happens because I have french punctuation in my training data (`ê`, `é` and friends).

I just propose that we use an UTF-8 encoding on the incoming data. I did prefer to use `f.write(data.encode("utf-8"))` instead of `f.write(data, encoding="utf-8")` for python 2.7 support.

Tested and working on my local server.

I'll wait for your input before writing tests and updating the changelog.

Fixes #524

**Status**:
- [x] ready for code review
- [ ] there are tests for the functionality
- [ ] documentation updated
- [ ] changelog updated
