### PR TITLE
one-line file entity_synonyms.json reformatted

### DIFF
--- a/rasa_nlu/extractors/entity_synonyms.py
+++ b/rasa_nlu/extractors/entity_synonyms.py
@@ -56,7 +56,7 @@ class EntitySynonymMapper(EntityExtractor):
         if self.synonyms:
             entity_synonyms_file = os.path.join(model_dir, "entity_synonyms.json")
             with io.open(entity_synonyms_file, 'w') as f:
-                f.write(str(json.dumps(self.synonyms)))
+                f.write(str(json.dumps(self.synonyms,indent=2,separators=(',', ': '))))
             return {"entity_synonyms": "entity_synonyms.json"}
         else:
             return {"entity_synonyms": None}


### PR DESCRIPTION
**Proposed changes**: reformat single-line json file
- Currently, entity_synonyms.json contains a single line. It poses difficulties for showing its content for example via Eclipse or various editors and for human-readability, if the file contains much information. Secondly, I see other json files in Rasa-NLU project are all of multiple-line style. So I suggest to reformat entity_synonyms.json

**Status**:
- [ ] ready for code review
- [ ] there are tests for the functionality
- [ ] documentation updated
- [ ] changelog updated
