### PR TITLE
If /parse contains query remap to q

### DIFF
--- a/_pytest/test_server.py
+++ b/_pytest/test_server.py
@@ -86,6 +86,10 @@ def test_version(app):
         [{"entities": {}, "confidence": 1.0, "intent": "greet", "_text": "hello"}]
     ),
     ResponseTest(
+        "http://dummy_uri/parse?query=hello",
+        [{"entities": {}, "confidence": 1.0, "intent": "greet", "_text": "hello"}]
+    ),
+    ResponseTest(
         "http://dummy_uri/parse?q=hello ńöñàśçií",
         [{"entities": {}, "confidence": 1.0, "intent": "greet", "_text": "hello ńöñàśçií"}]
     ),
@@ -108,6 +112,11 @@ def test_get_parse(app, response_test):
         "http://dummy_uri/parse",
         [{"entities": {}, "confidence": 1.0, "intent": "greet", "_text": "hello"}],
         payload={"q": "hello"}
+    ),
+    ResponseTest(
+        "http://dummy_uri/parse",
+        [{"entities": {}, "confidence": 1.0, "intent": "greet", "_text": "hello"}],
+        payload={"query": "hello"}
     ),
     ResponseTest(
         "http://dummy_uri/parse",

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -118,8 +118,7 @@ class RasaNLU(object):
             request_params = json.loads(request.content.read().decode('utf-8', 'strict'))
         
         if 'query' in request_params:
-            request_params['q'] = request_params['query']
-            request_params.pop('q', None)
+            request_params['q'] = request_params.pop('q')
         
         if 'q' not in request_params:
             request.setResponseCode(404)

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -118,7 +118,7 @@ class RasaNLU(object):
             request_params = json.loads(request.content.read().decode('utf-8', 'strict'))
         
         if 'query' in request_params:
-            request_params['q'] = request_params.pop('q')
+            request_params['q'] = request_params.pop('query')
         
         if 'q' not in request_params:
             request.setResponseCode(404)

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -116,6 +116,11 @@ class RasaNLU(object):
                               request.args.items()}
         else:
             request_params = json.loads(request.content.read().decode('utf-8', 'strict'))
+        
+        if 'query' in request_params:
+            request_params['q'] = request_params['query']
+            request_params.pop('q', None)
+        
         if 'q' not in request_params:
             request.setResponseCode(404)
             returnValue(json.dumps({"error": "Invalid parse parameter specified"}))


### PR DESCRIPTION
API.ai doesn't use `q` it uses `query`, rather than handling this in a custom way I think it makes sense to just allow people to submit either q or query and handle both.

**Proposed changes**:
- I'm just doing a simple check for `query` in the request parameters and replacing that with `q` if it exists.

**Status**:
- [x] ready for code review
- [x] there are tests for the functionality
- [ ] documentation updated
- [ ] changelog updated
