### PR TITLE
Fixed error in training preventing new training requests

### DIFF
--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -215,10 +215,17 @@ class DataRouter(object):
             self.project_store[project].update(model_dir)
             return model_dir
 
+        def training_errback(failure):
+            target_project = self.project_store.get(failure.value.failed_target_project)
+            if target_project:
+                target_project.status = 0
+            return failure
+
         logger.debug("New training queued")
 
         result = self.pool.submit(do_train_in_worker, train_config)
         result = deferred_from_future(result)
         result.addCallback(training_callback)
+        result.addErrback(training_errback)
 
         return result

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -13,10 +13,11 @@ from builtins import str
 
 from klein import Klein
 from twisted.internet import reactor, threads
-from twisted.internet.defer import inlineCallbacks, returnValue, maybeDeferred
+from twisted.internet.defer import inlineCallbacks, returnValue
 
 from rasa_nlu.config import RasaNLUConfig
 from rasa_nlu.data_router import DataRouter, InvalidProjectError, AlreadyTrainingError
+from rasa_nlu.train import TrainingException
 from rasa_nlu.version import __version__
 
 logger = logging.getLogger(__name__)
@@ -185,7 +186,7 @@ class RasaNLU(object):
         except InvalidProjectError as e:
             request.setResponseCode(404)
             returnValue(json.dumps({"error": "{}".format(e)}))
-        except ValueError as e:
+        except TrainingException as e:
             request.setResponseCode(500)
             returnValue(json.dumps({"error": "{}".format(e)}))
 

--- a/rasa_nlu/train.py
+++ b/rasa_nlu/train.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+
 import argparse
 import logging
 import os
@@ -9,6 +10,9 @@ import os
 import typing
 from typing import Text
 from typing import Tuple
+from typing import Optional
+
+from builtins import str
 
 from rasa_nlu.components import ComponentBuilder
 from rasa_nlu.converters import load_data
@@ -16,7 +20,6 @@ from rasa_nlu.model import Interpreter
 from rasa_nlu.model import Trainer
 
 from rasa_nlu.config import RasaNLUConfig
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/rasa_nlu/train.py
+++ b/rasa_nlu/train.py
@@ -12,8 +12,6 @@ from typing import Text
 from typing import Tuple
 from typing import Optional
 
-from builtins import str
-
 from rasa_nlu.components import ComponentBuilder
 from rasa_nlu.converters import load_data
 from rasa_nlu.model import Interpreter
@@ -57,7 +55,7 @@ class TrainingException(Exception):
 
     def __init__(self, failed_target_project, exception):
         self.failed_target_project = failed_target_project
-        self.message = str(exception)
+        self.message = exception.args[0]
 
     def __str__(self):
         return self.message

--- a/rasa_nlu/train.py
+++ b/rasa_nlu/train.py
@@ -53,9 +53,10 @@ class TrainingException(Exception):
           message -- explanation of why the request is invalid
       """
 
-    def __init__(self, failed_target_project, exception):
+    def __init__(self, failed_target_project=None, exception=None):
         self.failed_target_project = failed_target_project
-        self.message = exception.args[0]
+        if exception:
+            self.message = exception.args[0]
 
     def __str__(self):
         return self.message

--- a/tests/base/test_server.py
+++ b/tests/base/test_server.py
@@ -147,6 +147,20 @@ def test_post_train(app, rasa_default_train_data):
     assert "error" in rjs
 
 
+@utilities.slowtest
+@pytest.inlineCallbacks
+def test_post_train_internal_error(app, rasa_default_train_data):
+    response = app.post("http://dummy_uri/train?name=test",
+                        data=json.dumps({"data": "dummy_data_for_triggering_an_error"}),
+                        content_type='application/json')
+    time.sleep(3)
+    app.flush()
+    response = yield response
+    rjs = yield response.json()
+    assert response.code == 500, "The training data format is not valid"
+    assert "error" in rjs
+
+
 @pytest.inlineCallbacks
 def test_model_hot_reloading(app, rasa_default_train_data):
     query = "http://dummy_uri/parse?q=hello&project=my_keyword_model"


### PR DESCRIPTION
**Proposed changes**:
- If a training errored, the status of the project was not updated (still `training`) therefore preventing new training requests for this project. This introduce a new Exception wrapper returning the name of the project for which an exception occurred during training.

**Status**:
- [X] ready for code review