### PR TITLE
added server_model_directory argument in server.py

### DIFF
--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -44,6 +44,8 @@ def create_argparser():
     parser.add_argument('--pipeline',
                         help="The pipeline to use. Either a pipeline template "
                              "name or a list of components separated by comma")
+    parser.add_argument('--server_model_dirs',
+                        help="address of server_model_directory")
     parser.add_argument('-P', '--port',
                         type=int,
                         help='port on which to run server')

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -45,7 +45,7 @@ def create_argparser():
                         help="The pipeline to use. Either a pipeline template "
                              "name or a list of components separated by comma")
     parser.add_argument('--server_model_dirs',
-                        help="address of server_model_directory")
+                        help="Directory containing the model to be used by server or an object describing multiple models.")
     parser.add_argument('-P', '--port',
                         type=int,
                         help='port on which to run server')


### PR DESCRIPTION
Added server_model_arg in rsa_nlu/server.py.
It was giving error when using `python -m rasa_nlu.server -c config_spacy.json --server_model_dirs=./model_YYYYMMDD-HHMMSS` since no --server_model_dirs arg is present in server.py.
