### PR TITLE
Skip doc creation on PRs from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ after_success:
 jobs:
   include:
   - stage: docs
+    if: fork = false
     install:
     - sudo rm /etc/apt/sources.list.d/mongodb-3.2.list  # temp mongo certificate fix
     - sudo apt-get update


### PR DESCRIPTION
**Proposed changes**:
- fixes travis build by skipping the docs stage if a PR is originated in a fork

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
