### PR TITLE
fix s3 model training and loading

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ This project adheres to `Semantic Versioning`_ starting with version 0.7.0.
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note:: This version is not yet released and is under active development.
+Fixed
+-----
+- Fixed loading of default model from S3. Fixes #633
 
 
 [0.10.1] - 2017-10-06

--- a/docker/Dockerfile_devtest
+++ b/docker/Dockerfile_devtest
@@ -1,8 +1,0 @@
-FROM rasa/rasa_nlu:latest-full
-
-RUN pip install -r alt_requirements/requirements_dev.txt
-
-RUN pip install -e .
-
-ENTRYPOINT ["pytest"]
-CMD["tests/"]

--- a/docker/Dockerfile_devtest
+++ b/docker/Dockerfile_devtest
@@ -1,0 +1,8 @@
+FROM rasa/rasa_nlu:latest-full
+
+RUN pip install -r alt_requirements/requirements_dev.txt
+
+RUN pip install -e .
+
+ENTRYPOINT ["pytest"]
+CMD["tests/"]

--- a/rasa_nlu/config.py
+++ b/rasa_nlu/config.py
@@ -61,6 +61,8 @@ class InvalidConfigError(ValueError):
 
 
 class RasaNLUConfig(object):
+    DEFAULT_PROJECT_NAME = "default"
+    
     def __init__(self, filename=None, env_vars=None, cmdline_args=None):
 
         if filename is None and os.path.isfile(DEFAULT_CONFIG_LOCATION):

--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -73,8 +73,6 @@ def deferred_from_future(future):
 
 
 class DataRouter(object):
-    DEFAULT_PROJECT_NAME = "default"
-
     def __init__(self, config, component_builder):
         self._training_processes = config['max_training_processes'] if config['max_training_processes'] > 0 else 1
         self.config = config
@@ -124,7 +122,7 @@ class DataRouter(object):
             project_store[project] = Project(self.config, self.component_builder, project)
 
         if not project_store:
-            project_store[self.DEFAULT_PROJECT_NAME] = Project()
+            project_store[RasaNLUConfig.DEFAULT_PROJECT_NAME] = Project(self.config)
         return project_store
 
     def _create_emulator(self):
@@ -150,7 +148,7 @@ class DataRouter(object):
         return self.emulator.normalise_request_json(data)
 
     def parse(self, data):
-        project = data.get("project") or self.DEFAULT_PROJECT_NAME
+        project = data.get("project") or RasaNLUConfig.DEFAULT_PROJECT_NAME
         model = data.get("model")
 
         if project not in self.project_store:

--- a/rasa_nlu/persistor.py
+++ b/rasa_nlu/persistor.py
@@ -144,10 +144,8 @@ class AWSPersistor(Persistor):
         # type: (Text) -> List[Text]
         try:
             prefix = self._project_prefix(project)
-            model_objects = [str(b.key) for b in self.bucket.objects.all()
-                             if str(b.key).startswith(prefix)]
-            return [self._project_and_model_from_filename(obj)[1]
-                    for obj in model_objects]
+            return [self._project_and_model_from_filename(obj.key)[1]
+                    for obj in self.bucket.objects.filter(Prefix=prefix)]
         except Exception as e:
             logger.warn("Failed to list models for project {} in "
                         "AWS. {}".format(project, e))

--- a/rasa_nlu/persistor.py
+++ b/rasa_nlu/persistor.py
@@ -94,7 +94,7 @@ class Persistor(object):
     def _project_prefix(project):
         # type: (Text) -> Text
 
-        return '{}___'.format(project)
+        return '{}___'.format(project or RasaNLUConfig.DEFAULT_PROJECT_NAME)
 
     @staticmethod
     def _project_and_model_from_filename(filename):
@@ -143,10 +143,11 @@ class AWSPersistor(Persistor):
     def list_models(self, project):
         # type: (Text) -> List[Text]
         try:
-            blob_iterator = self.bucket.list(
-                    prefix=self._project_prefix(project))
-            return [self._project_and_model_from_filename(b.name)[1]
-                    for b in blob_iterator]
+            prefix = self._project_prefix(project)
+            model_objects = [str(b.key) for b in self.bucket.objects.all()
+                             if str(b.key).startswith(prefix)]
+            return [self._project_and_model_from_filename(obj)[1]
+                    for obj in model_objects]
         except Exception as e:
             logger.warn("Failed to list models for project {} in "
                         "AWS. {}".format(project, e))

--- a/rasa_nlu/project.py
+++ b/rasa_nlu/project.py
@@ -64,9 +64,11 @@ class Project(object):
             logger.warn("Invalid model requested. Using default")
 
         self._loader_lock.acquire()
-        if not self._models.get(model_name):
-            self._models[model_name] = self._interpreter_for_model(model_name)
-        self._loader_lock.release()
+        try:
+            if not self._models.get(model_name):
+                self._models[model_name] = self._interpreter_for_model(model_name)
+        finally:
+            self._loader_lock.release()
 
         response = self._models[model_name].parse(text, time)
 
@@ -124,7 +126,7 @@ class Project(object):
             data = Project._default_model_metadata()
             return Metadata(data, model_name)
         else:
-            if not os.path.isabs(model_name):
+            if not os.path.isabs(model_name) and self._path:
                 path = os.path.join(self._path, model_name)
             else:
                 path = model_name


### PR DESCRIPTION
Adds a fix for issue #633 (S3 persistence for models not working in 0.10.1). The issue is that models persistent in S3 are not loading on server startup.

**Proposed changes**:
- most important: update `rasa_nlu/persistor.py` to use API of boto3 (Seems to currently call methods from boto2 but boto3 is installed as per requirements. Compare http://boto.cloudhackers.com/en/latest/ref/s3.html#boto.s3.bucket.Bucket.list vs http://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Bucket.objects).
- extracts constant DEFAULT_PROJECT_NAME to `RasaNLUConfig` to make it accessible in both `rasa_nlu/data_router.py` and `rasa_nlu/persistor.py`. Required for loading models for project "default" since currently, it tried to load S3 objects whose key starts with "None_" but training creates objects with keys prefixed "default_".
- small fixes for lazy model loading in `rasa_nlu/project.py`: avoid error in absolute path construction if no path is given (happens for cloud storage) and ensures locks are released if loading fails (currently, server blocks after fail and must be restarted)

Plz let me know if you would like to merge this and if yes, how and what needs to change for that to happen. Would love to avoid having to maintain a fork :)

p.s.: I ran tests inside a container based off of `docker/Dockerfile_devtest` (included in PR for reference, started with `docker run -it --rm -v `pwd`/rasa_nlu:/app/rasa_nlu  <image_name> pytest tests/`). Tests said `148 passed` before and after my changes, so I hope I did not break anything important.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
