### PR TITLE
Update config.py

### DIFF
--- a/rasa_nlu/config.py
+++ b/rasa_nlu/config.py
@@ -148,7 +148,7 @@ class RasaNLUConfig(object):
         return cmdline_config
 
     def create_env_config(self, env_vars):
-        keys = [key for key in env_vars.keys() if "RASA" in key]
+        keys = [key for key in env_vars.keys() if "RASA_" in key]
         env_config = {key.split('RASA_')[1].lower(): env_vars[key] for key in keys}
         env_config = self.split_pipeline(env_config)
         env_config = self.split_arg(env_config, "duckling_dimensions")


### PR DESCRIPTION
A very special failure case where a container has other environment variables that start with RASA and doesn't have an "_". The server fails to start. 
Hope fully this helps.

**Proposed changes**:
- Modified the lookup to RASA_ instead of RASA under the environment variables.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality _(N/A)_
- [ ] updated the documentation _(N/A)_
- [ ] updated the changelog _(N/A)_
