### PR TITLE
Doc on dependency installation instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,7 +36,7 @@ installed and tell you which are missing, if any.
 
     .. code-block:: bash
 
-        pip install -r alt_requirements/dev-requirements.txt
+        pip install -r alt_requirements/requirements_full.txt
 
     to install all requirements.
 


### PR DESCRIPTION
**Proposed changes**:

Fixes filename for TIP on installing all dependencies.
Correct filename is `alt_requirements/requirements_full.txt`


**Status (please check what you already did)**:
- [] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
