### PR TITLE
Remove use of args.language in convert.py

### DIFF
--- a/rasa_nlu/convert.py
+++ b/rasa_nlu/convert.py
@@ -19,8 +19,8 @@ def create_argparser():
     return parser
 
 
-def convert_training_data(data_file, out_file, output_format, language):
-    td = load_data(data_file, language)
+def convert_training_data(data_file, out_file, output_format):
+    td = load_data(data_file)
     with io.open(out_file, "w", encoding='utf-8') as f:
         if output_format == 'md':
             f.write(td.as_markdown())
@@ -31,4 +31,4 @@ def convert_training_data(data_file, out_file, output_format, language):
 if __name__ == "__main__":
     parser = create_argparser()
     args = parser.parse_args()
-    convert_training_data(args.data_file, args.out_file, args.format, args.language)
+    convert_training_data(args.data_file, args.out_file, args.format)


### PR DESCRIPTION
**Proposed changes**:
- This release fixes a bug introduced in #625, since `convert.py` does not accept a `language` parameter and `converters.py#load_data` has a default value for the `language` parameter.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
