### PR TITLE
quick fix for None "_formatter_parser" bug

### DIFF
--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -164,7 +164,7 @@ class DataRouter(object):
         response, used_model = self.project_store[project].parse(data['text'], data.get('time', None), model)
 
         if self.responses:
-            self.responses.info(user_input=response, project=project, model=used_model)
+            self.responses.info('',user_input=response, project=project, model=used_model)
         return self.format_response(response)
 
     def format_response(self, data):


### PR DESCRIPTION
**Proposed changes**:
- This fixes the out-of-the-box failure generated by an info level logging statement that doesn't include a format string to format.  It's not a good fix (it adds an empty string), but it is at least concise.
```
curl -XPOST localhost:5000/parse -d '{"q":"hello there", "model": "default" }'
{"error": "'NoneType' object has no attribute '_formatter_parser'"}
```

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
