### PR TITLE
Fix missing storage config parameter

### DIFF
--- a/rasa_nlu/config.py
+++ b/rasa_nlu/config.py
@@ -33,6 +33,7 @@ DEFAULT_CONFIG = {
     "max_number_of_ngrams": 7,
     "pipeline": [],
     "response_log": "logs",
+    "storage": null,
     "aws_endpoint_url": None,
     "duckling_dimensions": None,
     "duckling_http_url": None,

--- a/rasa_nlu/config.py
+++ b/rasa_nlu/config.py
@@ -33,7 +33,7 @@ DEFAULT_CONFIG = {
     "max_number_of_ngrams": 7,
     "pipeline": [],
     "response_log": "logs",
-    "storage": null,
+    "storage": None,
     "aws_endpoint_url": None,
     "duckling_dimensions": None,
     "duckling_http_url": None,


### PR DESCRIPTION
**Proposed changes**: The latest master is throwing the following warning which signifies that the storage parameter in the config is missing:

WARNING:rasa_nlu.project:Failed to list models of project xxxxxx. u'No persistent storage specified. Supported values are aws, gcs'

Just added "storage": None,
- ...

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
