### PR TITLE
parsing-exception-stacktrace

### DIFF
--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -155,6 +155,7 @@ class RasaNLU(object):
                 returnValue(simplejson.dumps({"error": "{}".format(e)}))
             except Exception as e:
                 request.setResponseCode(500)
+                logger.exception(e)
                 returnValue(simplejson.dumps({"error": "{}".format(e)}))
 
     @app.route("/version", methods=['GET'])


### PR DESCRIPTION
Logging exceptions and their stack trace for internal server errors on parsing. Otherwise, it can be difficult to understand which pipeline component is having trouble. Even searching for the specific error message does not necessarily lead to results, since it might not originate from within rasa. 