### PR TITLE
New intent classifier for almost exactly match from training examples

### DIFF
--- a/rasa_nlu/classifiers/exact_intent_classifier.py
+++ b/rasa_nlu/classifiers/exact_intent_classifier.py
@@ -52,11 +52,17 @@ class ExactIntentClassifier(Component):
         msg_text = msg_text.strip() # with leading and trailing whitespace removed
 
         if msg_text in self._intent_data:
-            # clean previous classifier's decision, using this one only
-            message.set("intent", self._intent_data[msg_text], add_to_output=True)
+            predicted_intents = self._intent_data[msg_text]
 
-            # remove previous classifier's intent_ranking output if exists
-            message.data.pop('intent_ranking', None)
+            # if there two or more predicted intents,
+            # take first one as most confident one
+            most_likely_intent = predicted_intents[0]
+
+            # replace previous classifier's decision, using this one only
+            message.set("intent", most_likely_intent, add_to_output=True)
+
+            # replace previous classifier's intent_ranking
+            message.data['intent_ranking'] = predicted_intents
 
             # no more work
             return None

--- a/rasa_nlu/classifiers/exact_intent_classifier.py
+++ b/rasa_nlu/classifiers/exact_intent_classifier.py
@@ -54,7 +54,9 @@ class ExactIntentClassifier(Component):
         if msg_text in self._intent_data:
             # clean previous classifier's decision, using this one only
             message.set("intent", self._intent_data[msg_text], add_to_output=True)
-            del message.data['intent_ranking']
+
+            # remove previous classifier's intent_ranking output if exists
+            message.data.pop('intent_ranking', None)
 
             # no more work
             return None

--- a/rasa_nlu/classifiers/exact_intent_classifier.py
+++ b/rasa_nlu/classifiers/exact_intent_classifier.py
@@ -78,16 +78,11 @@ class ExactIntentClassifier(Component):
             text = e.text
             intent = e.data['intent']
 
-            msg_text = text.strip()  # with leading and trailing whitespace removed
-
             question_mark = config.get("trailing_punctuation_marks", "")
 
-            cleaned_message = msg_text.rstrip(question_mark)
-            patched_message = ["".join([msg_text, i]) for i in question_mark]
+            augmented_text = self._augment_text(text, question_mark)
 
-            augmented_msg = set([cleaned_message] + patched_message)
-
-            for m in augmented_msg:
+            for m in augmented_text:
                 self._intent_data[m].append(
                     {"name": intent, "confidence": 1.0}
                 )
@@ -97,6 +92,17 @@ class ExactIntentClassifier(Component):
             mean_score = 1 / len(intents)
             for i in intents:
                 i['confidence'] = mean_score
+
+    @staticmethod
+    def _augment_text(text, question_mark):
+        # with leading and trailing whitespace removed
+        text = text.strip()
+
+        cleaned_message = text.rstrip(question_mark)
+        patched_message = ["".join([text, i]) for i in question_mark]
+
+        augmented_msg = set([cleaned_message] + patched_message)
+        return augmented_msg
 
     @classmethod
     def load(cls, model_dir=None, model_metadata=None, cached_component=None, **kwargs):

--- a/rasa_nlu/classifiers/exact_intent_classifier.py
+++ b/rasa_nlu/classifiers/exact_intent_classifier.py
@@ -85,7 +85,7 @@ class ExactIntentClassifier(Component):
             cleaned_message = msg_text.rstrip(question_mark)
             patched_message = ["".join([msg_text, i]) for i in question_mark]
 
-            augmented_msg = set([cleaned_message] + patched_message + [msg_text])
+            augmented_msg = set([cleaned_message] + patched_message)
 
             for m in augmented_msg:
                 self._intent_data[m].append(

--- a/rasa_nlu/classifiers/exact_intent_classifier.py
+++ b/rasa_nlu/classifiers/exact_intent_classifier.py
@@ -62,7 +62,7 @@ class ExactIntentClassifier(Component):
             message.set("intent", most_likely_intent, add_to_output=True)
 
             # replace previous classifier's intent_ranking
-            message.data['intent_ranking'] = predicted_intents
+            message.set('intent_ranking', predicted_intents, add_to_output=True)
 
             # no more work
             return None

--- a/rasa_nlu/classifiers/exact_intent_classifier.py
+++ b/rasa_nlu/classifiers/exact_intent_classifier.py
@@ -1,0 +1,118 @@
+# -*-coding: utf-8-*-
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import collections
+import os
+
+try:
+    import pickle
+except ImportError:
+    import cPickle as pickle
+
+
+from builtins import map
+
+import typing
+from typing import Any
+from typing import Dict
+from typing import Text
+from typing import Optional
+
+from rasa_nlu.components import Component
+from rasa_nlu.training_data import Message
+
+PERSIST_MODEL_FILE = 'exact_classifier.pkl'
+
+if typing.TYPE_CHECKING:
+    from rasa_nlu.training_data import TrainingData
+    from rasa_nlu.config import RasaNLUConfig
+
+
+class ExactIntentClassifier(Component):
+
+    name = "intent_classifier_exact"
+
+    provides = ["intent"]
+
+    def __init__(self):
+        self._intent_data = collections.defaultdict(list)
+
+        super(ExactIntentClassifier, self).__init__()
+
+    def set_persist_data(self, intent_data):
+        self._intent_data = intent_data
+
+    def process(self, message, **kwargs):
+        # type: (Message, **Any) -> None
+        msg_text = message.text
+        msg_text = msg_text.strip() # with leading and trailing whitespace removed
+
+        if msg_text in self._intent_data:
+            # clean previous classifier's decision, using this one only
+            message.set("intent", self._intent_data[msg_text], add_to_output=True)
+            del message.data['intent_ranking']
+
+            # no more work
+            return None
+
+    def persist(self, model_dir):
+        # type: (Text) -> Optional[Dict[Text, Any]]
+
+        model_data = os.path.join(model_dir, PERSIST_MODEL_FILE)
+        with open(model_data, 'wb') as fd:
+            pickle.dump(self._intent_data, fd)
+
+        return {
+            "intent_classifier_keyword": PERSIST_MODEL_FILE,
+        }
+
+    def train(self, training_data, config, **kwargs):
+        # type: (TrainingData, RasaNLUConfig, **Any) -> None
+
+        # split intent to different text
+        for e in training_data.intent_examples:
+            text = e.text
+            intent = e.data['intent']
+
+            msg_text = text.strip()  # with leading and trailing whitespace removed
+
+            question_mark = config.get("trailing_punctuation_marks", "")
+
+            cleaned_message = msg_text.rstrip(question_mark)
+            patched_message = ["".join([msg_text, i]) for i in question_mark]
+
+            augmented_msg = set([cleaned_message] + patched_message + [msg_text])
+
+            for m in augmented_msg:
+                self._intent_data[m].append(
+                    {"name": intent, "confidence": 1.0}
+                )
+
+        # re-calculate the score
+        for intents in self._intent_data.values():
+            mean_score = 1 / len(intents)
+            for i in intents:
+                i['confidence'] = mean_score
+
+    @classmethod
+    def load(cls, model_dir=None, model_metadata=None, cached_component=None, **kwargs):
+        # type: (Text, Metadata, Optional[Component], **Any) -> Component
+        """Load this component from file.
+
+        After a component got trained, it will be persisted by calling `persist`. When the pipeline gets loaded again,
+         this component needs to be able to restore itself. Components can rely on any context attributes that are
+         created by `pipeline_init` calls to components previous to this one."""
+
+        model_data = os.path.join(model_dir, PERSIST_MODEL_FILE)
+
+        with open(model_data, 'rb') as fd:
+            intent_data = pickle.load(fd)
+
+        new_instance = cls()
+        new_instance.set_persist_data(intent_data)
+
+        return cached_component if cached_component else new_instance

--- a/rasa_nlu/config.py
+++ b/rasa_nlu/config.py
@@ -1,3 +1,5 @@
+# -*-coding: utf-8-*-
+
 from __future__ import unicode_literals
 from __future__ import print_function
 from __future__ import division
@@ -49,7 +51,8 @@ DEFAULT_CONFIG = {
     "intent_classifier_sklearn": {
         "C": [1, 2, 5, 10, 20, 100],
         "kernel": "linear"
-    }
+    },
+    "trailing_punctuation_marks": "?？"  # default values are english question mark and chinese question mark
 }
 
 

--- a/rasa_nlu/registry.py
+++ b/rasa_nlu/registry.py
@@ -19,6 +19,7 @@ from typing import Type
 
 from rasa_nlu.classifiers.keyword_intent_classifier import \
     KeywordIntentClassifier
+from rasa_nlu.classifiers.exact_intent_classifier import ExactIntentClassifier
 from rasa_nlu.classifiers.mitie_intent_classifier import MitieIntentClassifier
 from rasa_nlu.classifiers.sklearn_intent_classifier import \
     SklearnIntentClassifier
@@ -53,6 +54,7 @@ component_classes = [
     SpacyFeaturizer, MitieFeaturizer, NGramFeaturizer, RegexFeaturizer,
     MitieTokenizer, SpacyTokenizer, WhitespaceTokenizer,
     SklearnIntentClassifier, MitieIntentClassifier, KeywordIntentClassifier,
+    ExactIntentClassifier
 ]
 
 # Mapping from a components name to its class to allow name based lookup.

--- a/rasa_nlu/registry.py
+++ b/rasa_nlu/registry.py
@@ -116,6 +116,7 @@ registered_pipeline_templates = {
         "intent_classifier_keyword",
         "intent_classifier_sklearn",
         "intent_classifier_mitie",
+        "intent_classifier_exact"
     ]
 }
 

--- a/sample_configs/config_defaults.json
+++ b/sample_configs/config_defaults.json
@@ -36,5 +36,6 @@
   "intent_classifier_sklearn": {
     "C": [1, 2, 5, 10, 20, 100],
     "kernel": "linear"
-  }
+  },
+  "trailing_punctuation_marks": "?？"
 }


### PR DESCRIPTION
**Proposed changes**:
Here I propose a new intent classifier: `exact_intent_classifier`. 

`exact_intent_classifier` try to solve an embarrassing situation: some time model performance is so bad even you give an input text that exists in training examples but the model still give the wrong answer!

`exact_intent_classifier` remember the training examples almost exactly, when those example text come in again, `exact_intent_classifier` will output the right answer and confidence is 1. 

`exact_intent_classifier` also have an config option: `trailing_punctuation_marks` that make classifier more powerful. classifier will make sure that without or with one of `trailing_punctuation_marks` will treat as same input. Such as `trailing_punctuation_marks` set to "?" means "where are you" and "where are you?" will treat as same thing.

`exact_intent_classifier` is designed to work with other classifiers, so it can always boost the performance more or less.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
