### PR TITLE
Replace api.ai mentions with Dialogflow in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ curl 'http://localhost:5000/parse?q=hello&model=test_model'
 # FAQ
 
 ### Who is it for?
-The intended audience is mainly __people developing bots__, starting from scratch or looking to find a a drop-in replacement for [wit](https://wit.ai), [LUIS](https://luis.ai), or [api.ai](https://api.ai). The setup process is designed to be as simple as possible. Rasa NLU is written in Python, but you can use it from any language through a [HTTP API](https://rasahq.github.io/rasa_nlu/http.html). If your project is written in Python you can [simply import the relevant classes](https://rasahq.github.io/rasa_nlu/python.html). If you're currently using wit/LUIS/api.ai, you just:
+The intended audience is mainly __people developing bots__, starting from scratch or looking to find a a drop-in replacement for [wit](https://wit.ai), [LUIS](https://luis.ai), or [Dialogflow](https://dialogflow.com). The setup process is designed to be as simple as possible. Rasa NLU is written in Python, but you can use it from any language through a [HTTP API](https://rasahq.github.io/rasa_nlu/http.html). If your project is written in Python you can [simply import the relevant classes](https://rasahq.github.io/rasa_nlu/python.html). If you're currently using wit/LUIS/Dialogflow, you just:
 
-1. Download your app data from wit, LUIS, or api.ai and feed it into Rasa NLU
+1. Download your app data from wit, LUIS, or Dialogflow and feed it into Rasa NLU
 2. Run Rasa NLU on your machine and switch the URL of your wit/LUIS api calls to `localhost:5000/parse`.
 
 ### Why should I use Rasa NLU?


### PR DESCRIPTION
**Proposed changes**:
- Replaced `api.ai` mentions with `Dialogflow` in README
