### PR TITLE
Remove Model Naming Requirement for loading

### DIFF
--- a/rasa_nlu/project.py
+++ b/rasa_nlu/project.py
@@ -183,5 +183,4 @@ class Project(object):
             return []
         else:
             return [model
-                    for model in os.listdir(path)
-                    if model.startswith(MODEL_NAME_PREFIX)]
+                    for model in os.listdir(path)]


### PR DESCRIPTION
**Proposed changes**:
- Currently only models that start with `model_` are loaded and shown in the `/status` endpoint.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog