### PR TITLE
Add Dockerfile for testing spaCy 2

### DIFF
--- a/alt_requirements/requirements_spacy_2.txt
+++ b/alt_requirements/requirements_spacy_2.txt
@@ -1,0 +1,7 @@
+# Minimum Instal Requirements
+-r requirements_bare.txt
+
+spacy==2.0.4
+scikit-learn==0.19.1
+scipy==1.0.0
+sklearn-crfsuite==0.3.6

--- a/docker/Dockerfile_spacy_2
+++ b/docker/Dockerfile_spacy_2
@@ -1,0 +1,43 @@
+FROM python:2.7-slim
+
+ENV RASA_NLU_DOCKER="YES" \
+    RASA_NLU_HOME=/app \
+    RASA_NLU_PYTHON_PACKAGES=/usr/local/lib/python2.7/dist-packages
+
+# Run updates, install basics and cleanup
+# - build-essential: Compile specific dependencies
+# - git-core: Checkout git repos
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends build-essential git-core \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR ${RASA_NLU_HOME}
+
+COPY . ${RASA_NLU_HOME}
+
+# use bash always
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+RUN pip install -r alt_requirements/requirements_spacy_2.txt
+
+RUN pip install -e .
+
+RUN pip install -U spacy \
+    && python -m spacy download en \
+    && python -m spacy download de \
+    && python -m spacy download es \
+    && python -m spacy download pt \
+    && python -m spacy download fr \
+    && python -m spacy download it \
+    && python -m spacy download nl \
+    && python -m spacy download xx
+
+COPY sample_configs/config_spacy.json ${RASA_NLU_HOME}/config.json
+
+VOLUME ["/app/projects", "/app/logs", "/app/data"]
+
+EXPOSE 5000
+
+ENTRYPOINT ["./entrypoint.sh"]
+CMD ["start", "-c", "config.json"]


### PR DESCRIPTION
**Proposed changes**:
- Add a dockerfile for testing spaCy 2.0.
- It does not include the java install to make it lighter.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog

I wanted to test spacy 2 so I created a Dockerfile inspired in the existing ones to update the dependencies. 

Using my branch it can be build by running:

```
# cd into the repository root and run
docker build -t rasa_nlu_spacy_2 -f docker/Dockerfile_spacy_2 .
```

The docker image builds fine and the server responds to status/train/parse endpoints. However, I suspect the api changes in spaCy will requre some work. For instance, I could not get any entity recognition as of yet. Just for reference this is the response I got after training the model with de turorial data.

```
{
    "entities": [],
    "intent": {
        "confidence": 0.8637091057193137,
        "name": "restaurant_search"
    },
    "text": "I am looking for Chinese food",
    "intent_ranking": [
        {
            "confidence": 0.8637091057193137,
            "name": "restaurant_search"
        },
        {
            "confidence": 0.07029118228175456,
            "name": "affirm"
        },
        {
            "confidence": 0.035034523563475625,
            "name": "greet"
        },
        {
            "confidence": 0.030965188435455922,
            "name": "goodbye"
        }
    ]
}
```

Related issue: #456 
