### PR TITLE
Avoid UnicodeEncodeError by using repr() in warning

### DIFF
--- a/rasa_nlu/extractors/entity_synonyms.py
+++ b/rasa_nlu/extractors/entity_synonyms.py
@@ -85,13 +85,17 @@ class EntitySynonymMapper(EntityExtractor):
     def add_entities_if_synonyms(self, entity_a, entity_b):
         if entity_b is not None:
             original = entity_a if isinstance(entity_a, six.text_type) else six.text_type(entity_a)
+
             replacement = entity_b if isinstance(entity_b, six.text_type) else six.text_type(entity_b)
 
             if original != replacement:
                 original = original.lower()
                 if original in self.synonyms and self.synonyms[original] != replacement:
-                    warnings.warn("Found conflicting synonym definitions for %s. Overwriting "
-                                  "target %s with %s. Check your training data and remove conflicting "
-                                  "synonym definitions to prevent this from happening." %
-                                  (original, self.synonyms[original], replacement))
+                    warnings.warn("Found conflicting synonym definitions for {}. Overwriting "
+                                  "target {} with {}. Check your training data and remove conflicting "
+                                  "synonym definitions to prevent this from happening.".format(repr(original),
+                                                                                               repr(self.synonyms[
+                                                                                                        original]),
+                                                                                               repr(replacement)))
+
                 self.synonyms[original] = replacement


### PR DESCRIPTION
**Proposed changes**:
- Non-ASCII characters in entity synonyms can generate a `UnicodeEncodeError`
- this is avoided by wrapping each argument of the warning message with `repr()`


**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
