### PR TITLE
Fix bug in MarkDown to JSON conversion

### DIFF
--- a/rasa_nlu/utils/md_to_json.py
+++ b/rasa_nlu/utils/md_to_json.py
@@ -21,8 +21,7 @@ INTENT_PARSING_STATE = "intent"
 SYNONYM_PARSING_STATE = "synonym"
 
 def strip_comments(comment_regex,text): 
-    """ Removes comments defined by the argument 'comment_regex' from the 
-    given text"""
+    """ Removes comments defined by `comment_regex` from `text`. """ 
     return re.sub(comment_regex,'',text)
 
 

--- a/rasa_nlu/utils/md_to_json.py
+++ b/rasa_nlu/utils/md_to_json.py
@@ -15,9 +15,15 @@ ent_regex_with_value = re.compile('\[(?P<synonym>[^\]]+)'
 intent_regex = re.compile('##\s*intent:(.+)')
 synonym_regex = re.compile('##\s*synonym:(.+)')
 example_regex = re.compile('\s*-\s*(.+)')
+comment_regex = re.compile('\s*<!--.*-->\s*')
 
 INTENT_PARSING_STATE = "intent"
 SYNONYM_PARSING_STATE = "synonym"
+
+def strip_comments(comment_regex,text): 
+    """ Removes comments defined by the argument 'comment_regex' from the 
+    given text"""
+    return re.sub(comment_regex,'',text)
 
 
 class MarkdownToJson(object):
@@ -36,6 +42,7 @@ class MarkdownToJson(object):
 
         with io.open(self.file_name, 'rU', encoding="utf-8-sig") as f:
             for row in f:
+                row = strip_comments(comment_regex,row) # Strip the comments from the line
                 intent_match = re.search(intent_regex, row)
                 if intent_match is not None:
                     self._set_current_state(


### PR DESCRIPTION

**Proposed changes**:
- Add a strip_comments() function in md_to_json.py which removes MarkDown
	comments from a line
- The function uses a regexp to detect and remove comments
- Call the function before processing each line of the file being read

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
