### PR TITLE
Fixing the case sensitive issue for intent classification

### DIFF
--- a/rasa_nlu/utils/spacy_utils.py
+++ b/rasa_nlu/utils/spacy_utils.py
@@ -72,12 +72,12 @@ class SpacyNLP(Component):
         # type: (TrainingData) -> Dict[Text, Any]
 
         for example in training_data.training_examples:
-            example.set("spacy_doc", self.nlp(example.text))
+            example.set("spacy_doc", self.nlp(example.text.lower()))
 
     def process(self, message, **kwargs):
         # type: (Message, **Any) -> None
 
-        message.set("spacy_doc", self.nlp(message.text))
+        message.set("spacy_doc", self.nlp(message.text.lower()))
 
     def persist(self, model_dir):
         # type: (Text) -> Dict[Text, Any]


### PR DESCRIPTION
I noticed because of case sensitivity, the SVM intent classification is failing in some cases. For example, the text '**hello**' with different cases results different classification. So using the lowercase for spacy_doc in both training and request processing.

> MVUNDELA-MBP:rasa mvundela$ curl 'http://localhost:5001/parse?q=**Hello**'
> {"entities": [{"start": 0, "extractor": "ner_crf", "end": 5, "value": "Hello", "entity": "greetings_identifier"}], "intent": {"confidence": 0.9475492827995153, "name": "**smalltalk_greetings**"}, "text": "Hello", "intent_ranking": [{"confidence": 0.9475492827995153, "name": "smalltalk_greetings"}, {"confidence": 0.016386606127676846, "name": "smalltalk_positive"}, {"confidence": 0.008669188232799085, "name": "smalltalk_negative"}, {"confidence": 0.006202887909878722, "name": "smalltalk_ignore"}, {"confidence": 0.0057271170630072135, "name": "smalltalk_repeat"}, {"confidence": 0.002737255480299946, "name": "hub_conflicts"}, {"confidence": 0.002414905314141892, "name": "smalltalk_thanks"}, {"confidence": 0.001984493260891949, "name": "smalltalk_siri_hi_joke"}, {"confidence": 0.0015533677593968687, "name": "hub_conflicts_cancellation"}, {"confidence": 0.0015104619536991082, "name": "stock_quotes"}]}
>  
> MVUNDELA-MBP:rasa mvundela$ curl 'http://localhost:5001/parse?q=**hello**'
> {"entities": [{"start": 0, "extractor": "ner_crf", "end": 5, "value": "hello", "entity": "greetings_identifier"}], "intent": {"confidence": 0.6261901523890995, "name": "**smalltalk_positive**"}, "text": "hello", "intent_ranking": [{"confidence": 0.6261901523890995, "name": "smalltalk_positive"}, {"confidence": 0.13437970870910626, "name": "smalltalk_greetings"}, {"confidence": 0.12474285102791922, "name": "smalltalk_negative"}, {"confidence": 0.03005931292668782, "name": "smalltalk_ignore"}, {"confidence": 0.023320983017165203, "name": "smalltalk_repeat"}, {"confidence": 0.011698138398341568, "name": "smalltalk_thanks"}, {"confidence": 0.008315483063515115, "name": "hub_conflicts_cancellation"}, {"confidence": 0.008081358998743817, "name": "smalltalk_siri_hi_joke"}, {"confidence": 0.008042940856172779, "name": "hub_conflicts"}, {"confidence": 0.00486819248497453, "name": "stock_quotes"}]}
> 
