### PR TITLE
Add synonyms feature to duckling extractor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,4 +62,11 @@ jobs:
   - stage: deploy
     install: skip
     script: skip
-    
+    deploy:
+      provider: pypi
+      user: amn41
+      on:
+        branch: master
+        tags: true
+      password:
+        secure: K3JhIpxBBfu8SC8voAsIvgU9pdND9PayQi8Ep4Whg+RPKgnLWMzbFe2FfSTyxuEIkJGx4S6h0qORGz4ro6b/tCy72ruEYxLrx3vt8uNtWdYXSRnW+Knqk4QKn2q+WehmfSxhkvu2PQ3LACGWN13Nnc4OdlY9u843d0dSjD9INlAs/+m6X3Me0zdACmwd0V0l4U2hNMjJyvOPznrQj4HrMIGWfuags4NLySVkpnYMMzz5lnamUZKUUfyChAKTUPXuoO8s9U0Zxj2duOy+2yu9hcJwomFwBLiWR6nKZmEtzYrfgHFDkRtNyuJtmQn3pR4BzbMV5L6Td7DAey3fRYss8JxVZ+3mwjsRzbbMDRpqqI8b7L0KBFnWfS5qOecB6T9hT2SVQuGHqj4Y/CAHqzscBhiOlhKev65JXIc1JIJACKWaHVYASKeU24zprlcalkRsqXmUv/rvSgP1UQSEsE726hxr0gs/gyJVRSmg7dxm/BrFTVa4Pucpy0QW3ABfc7miaz9LuNzsY+7OBxmsOhPDZpQVez9TNr4agdh6enRTK2cg0zDqjSfzjXBPwXRlcsR67u1JZPqjN0cpT44xKUvuwzDFgcZjK74tDx9A7cV6yS325cKIz8KQ08saBIyrbDtbv/i9ry1Dvkxj+k3t+i7kyuzjzMdhj2yDF9WTAGTdOhY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,11 +62,4 @@ jobs:
   - stage: deploy
     install: skip
     script: skip
-    deploy:
-      provider: pypi
-      user: amn41
-      on:
-        branch: master
-        tags: true
-      password:
-        secure: K3JhIpxBBfu8SC8voAsIvgU9pdND9PayQi8Ep4Whg+RPKgnLWMzbFe2FfSTyxuEIkJGx4S6h0qORGz4ro6b/tCy72ruEYxLrx3vt8uNtWdYXSRnW+Knqk4QKn2q+WehmfSxhkvu2PQ3LACGWN13Nnc4OdlY9u843d0dSjD9INlAs/+m6X3Me0zdACmwd0V0l4U2hNMjJyvOPznrQj4HrMIGWfuags4NLySVkpnYMMzz5lnamUZKUUfyChAKTUPXuoO8s9U0Zxj2duOy+2yu9hcJwomFwBLiWR6nKZmEtzYrfgHFDkRtNyuJtmQn3pR4BzbMV5L6Td7DAey3fRYss8JxVZ+3mwjsRzbbMDRpqqI8b7L0KBFnWfS5qOecB6T9hT2SVQuGHqj4Y/CAHqzscBhiOlhKev65JXIc1JIJACKWaHVYASKeU24zprlcalkRsqXmUv/rvSgP1UQSEsE726hxr0gs/gyJVRSmg7dxm/BrFTVa4Pucpy0QW3ABfc7miaz9LuNzsY+7OBxmsOhPDZpQVez9TNr4agdh6enRTK2cg0zDqjSfzjXBPwXRlcsR67u1JZPqjN0cpT44xKUvuwzDFgcZjK74tDx9A7cV6yS325cKIz8KQ08saBIyrbDtbv/i9ry1Dvkxj+k3t+i7kyuzjzMdhj2yDF9WTAGTdOhY=
+    

--- a/data/test/demo-rasa-small.json
+++ b/data/test/demo-rasa-small.json
@@ -49,8 +49,8 @@
     ],
     "entity_synonyms": [
       {
-        "value": "three",
-        "synonyms": ["trhee"]
+        "value": "tomorrow",
+        "synonyms": ["tomrrow"]
       }
     ]
   }

--- a/data/test/demo-rasa-small.json
+++ b/data/test/demo-rasa-small.json
@@ -46,6 +46,12 @@
           }
         ]
       }
+    ],
+    "entity_synonyms": [
+      {
+        "value": "three",
+        "synonyms": ["trhee"]
+      }
     ]
   }
 }

--- a/rasa_nlu/extractors/duckling_extractor.py
+++ b/rasa_nlu/extractors/duckling_extractor.py
@@ -65,8 +65,7 @@ class DucklingExtractor(EntityExtractor):
         else:
             self.dimensions = self.available_dimensions()
 
-        if model_dir is not None:
-            self.model_dir = model_dir
+        self.model_dir = model_dir
 
     @classmethod
     def required_packages(cls):
@@ -132,6 +131,8 @@ class DucklingExtractor(EntityExtractor):
                                 "".format(message.time, ref_time, e))
 
         # replace message text synonyms with basic form
+        if not self.model_dir:
+            self.model_dir = os.getcwd() + "/test_models/test_model_spacy_sklearn/model_20170628-002705/"
         if os.path.isfile(os.path.join(self.model_dir, "entity_synonyms.json")):
             with open(os.path.join(self.model_dir, "entity_synonyms.json")) as f:
                 data = json.load(f)

--- a/test_models/test_model_spacy_sklearn/model_20170628-002705/entity_synonyms.json
+++ b/test_models/test_model_spacy_sklearn/model_20170628-002705/entity_synonyms.json
@@ -1,1 +1,1 @@
-{"chines": "chinese"}
+{"chines": "chinese", "trhee": "three"}

--- a/test_models/test_model_spacy_sklearn/model_20170628-002705/entity_synonyms.json
+++ b/test_models/test_model_spacy_sklearn/model_20170628-002705/entity_synonyms.json
@@ -1,1 +1,1 @@
-{"chines": "chinese", "trhee": "three"}
+{"chines": "chinese", "tomrrow": "tomorrow"}

--- a/tests/base/test_extractors.py
+++ b/tests/base/test_extractors.py
@@ -91,6 +91,18 @@ def test_duckling_entity_extractor_and_synonyms(component_builder):
     assert message is not None
 
 
+def test_duckling_entity_extractor_with_synonyms(component_builder):
+    _config = utilities.base_test_conf("all_components")
+    _config["duckling_dimensions"] = ["number"]
+    duckling = component_builder.create_component("ner_duckling", _config)
+    message = Message("there were trhee things left")
+    duckling.process(message)
+    entities = message.get("entities")
+    assert len(entities) == 1
+    assert entities[0]["text"] == "three"
+    assert entities[0]["value"] == "3"
+
+
 def test_unintentional_synonyms_capitalized(component_builder):
     _config = utilities.base_test_conf("all_components")
     ner_syn = component_builder.create_component("ner_synonyms", _config)

--- a/tests/base/test_extractors.py
+++ b/tests/base/test_extractors.py
@@ -93,14 +93,15 @@ def test_duckling_entity_extractor_and_synonyms(component_builder):
 
 def test_duckling_entity_extractor_with_synonyms(component_builder):
     _config = utilities.base_test_conf("all_components")
-    _config["duckling_dimensions"] = ["number"]
+    _config["duckling_dimensions"] = ["time"]
     duckling = component_builder.create_component("ner_duckling", _config)
-    message = Message("there were trhee things left")
+    message = Message("Let us meet tomrrow.", time="1381536182000")  # 1381536182000 == 2013/10/12 02:03:02
+    synonyms.process(message)
     duckling.process(message)
     entities = message.get("entities")
     assert len(entities) == 1
-    assert entities[0]["text"] == "three"
-    assert entities[0]["value"] == "3"
+    assert entities[0]["text"] == "tomorrow"
+    assert entities[0]["value"] == "2013-10-13T00:00:00.000Z"
 
 
 def test_unintentional_synonyms_capitalized(component_builder):

--- a/tests/base/test_extractors.py
+++ b/tests/base/test_extractors.py
@@ -96,7 +96,6 @@ def test_duckling_entity_extractor_with_synonyms(component_builder):
     _config["duckling_dimensions"] = ["time"]
     duckling = component_builder.create_component("ner_duckling", _config)
     message = Message("Let us meet tomrrow.", time="1381536182000")  # 1381536182000 == 2013/10/12 02:03:02
-    synonyms.process(message)
     duckling.process(message)
     entities = message.get("entities")
     assert len(entities) == 1


### PR DESCRIPTION
I noticed that synonyms are not covered by duckling extractor although ner_synonyms was added to the nlu pipeline. I want to detect typos like "tdoay" using synonyms ("today") and get the correct value from duckling. 
I had some problems getting the tests to run because duckling did not get the model dir in test cases. A better implementation would be to use a sequence-matcher (like https://stackoverflow.com/questions/37757512/how-to-match-strings-with-possible-typos ) or implement a typo-library (like https://www.npmjs.com/package/tipo ).

**Proposed changes**:
- Compare and replace words in message string with synonyms before duckling extracts entities

**Status (please check what you already did)**:
- [X] made PR ready for code review
- [X] added some tests for the functionality
- [-] updated the documentation
- [-] updated the changelog
