### PR TITLE
Allow to use split training files into multiple files (#180)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ This project adheres to `Semantic Versioning`_ starting with version 0.7.0.
 
 Added
 -----
+- support for splitting training data into multiple files (markdown and JSON only)
 
 Changed
 -------

--- a/data/examples/rasa/multiple_files_json/demo-rasa-affirm.json
+++ b/data/examples/rasa/multiple_files_json/demo-rasa-affirm.json
@@ -1,0 +1,61 @@
+{
+  "rasa_nlu_data": {
+    "common_examples": [
+      {
+        "text": "yes", 
+        "intent": "affirm", 
+        "entities": []
+      }, 
+      {
+        "text": "yep", 
+        "intent": "affirm", 
+        "entities": []
+      }, 
+      {
+        "text": "yeah", 
+        "intent": "affirm", 
+        "entities": []
+      },
+      {
+        "text": "indeed",
+        "intent": "affirm",
+        "entities": []
+      },
+      {
+        "text": "that's right",
+        "intent": "affirm",
+        "entities": []
+      },
+      {
+        "text": "ok",
+        "intent": "affirm",
+        "entities": []
+      },
+      {
+        "text": "great",
+        "intent": "affirm",
+        "entities": []
+      },
+      {
+        "text": "right, thank you",
+        "intent": "affirm",
+        "entities": []
+      },
+      {
+        "text": "correct",
+        "intent": "affirm",
+        "entities": []
+      },
+      {
+        "text": "great choice",
+        "intent": "affirm",
+        "entities": []
+      },
+      {
+        "text": "sounds really good",
+        "intent": "affirm",
+        "entities": []
+      }
+    ]
+  }
+}

--- a/data/examples/rasa/multiple_files_json/demo-rasa-goodbye.json
+++ b/data/examples/rasa/multiple_files_json/demo-rasa-goodbye.json
@@ -1,0 +1,46 @@
+{
+  "rasa_nlu_data": {
+    "common_examples": [
+      {
+        "text": "bye", 
+        "intent": "goodbye", 
+        "entities": []
+      }, 
+      {
+        "text": "goodbye", 
+        "intent": "goodbye", 
+        "entities": []
+      }, 
+      {
+        "text": "good bye", 
+        "intent": "goodbye", 
+        "entities": []
+      }, 
+      {
+        "text": "stop", 
+        "intent": "goodbye", 
+        "entities": []
+      }, 
+      {
+        "text": "end", 
+        "intent": "goodbye", 
+        "entities": []
+      },
+      {
+        "text": "farewell",
+        "intent": "goodbye",
+        "entities": []
+      },
+      {
+        "text": "Bye bye",
+        "intent": "goodbye",
+        "entities": []
+      },
+      {
+        "text": "have a good one",
+        "intent": "goodbye",
+        "entities": []
+      }
+    ]
+  }
+}

--- a/data/examples/rasa/multiple_files_json/demo-rasa-greet.json
+++ b/data/examples/rasa/multiple_files_json/demo-rasa-greet.json
@@ -1,0 +1,46 @@
+{
+  "rasa_nlu_data": {
+    "common_examples": [
+      {
+        "text": "hey", 
+        "intent": "greet", 
+        "entities": []
+      }, 
+      {
+        "text": "howdy", 
+        "intent": "greet", 
+        "entities": []
+      }, 
+      {
+        "text": "hey there",
+        "intent": "greet", 
+        "entities": []
+      }, 
+      {
+        "text": "hello", 
+        "intent": "greet", 
+        "entities": []
+      }, 
+      {
+        "text": "hi", 
+        "intent": "greet", 
+        "entities": []
+      },
+      {
+        "text": "good morning",
+        "intent": "greet",
+        "entities": []
+      },
+      {
+        "text": "good evening",
+        "intent": "greet",
+        "entities": []
+      },
+      {
+        "text": "dear sir",
+        "intent": "greet",
+        "entities": []
+      }
+    ]
+  }
+}

--- a/data/examples/rasa/multiple_files_json/demo-rasa-restaurant_search.json
+++ b/data/examples/rasa/multiple_files_json/demo-rasa-restaurant_search.json
@@ -1,0 +1,179 @@
+{
+  "rasa_nlu_data": {
+    "entity_synonyms": [
+      {
+        "value": "chinese",
+        "synonyms": ["Chinese", "Chines", "chines"]
+      },
+      {
+        "value": "vegetarian",
+        "synonyms": ["veggie", "vegg"]
+      }
+    ],
+    "common_examples": [
+      {
+        "text": "i'm looking for a place to eat",
+        "intent": "restaurant_search",
+        "entities": []
+      },
+      {
+        "text": "I want to grab lunch",
+        "intent": "restaurant_search",
+        "entities": []
+      },
+      {
+        "text": "I am searching for a dinner spot",
+        "intent": "restaurant_search",
+        "entities": []
+      },
+      {
+        "text": "i'm looking for a place in the north of town",
+        "intent": "restaurant_search",
+        "entities": [
+          {
+            "start": 31,
+            "end": 36,
+            "value": "north",
+            "entity": "location"
+          }
+        ]
+      },
+      {
+        "text": "show me chinese restaurants",
+        "intent": "restaurant_search",
+        "entities": [
+          {
+            "start": 8,
+            "end": 15,
+            "value": "chinese",
+            "entity": "cuisine"
+          }
+        ]
+      },
+      {
+        "text": "show me chines restaurants",
+        "intent": "restaurant_search",
+        "entities": [
+          {
+            "start": 8,
+            "end": 14,
+            "value": "chinese",
+            "entity": "cuisine"
+          }
+        ]
+      },
+      {
+        "text": "show me a mexican place in the centre", 
+        "intent": "restaurant_search", 
+        "entities": [
+          {
+            "start": 31, 
+            "end": 37, 
+            "value": "centre", 
+            "entity": "location"
+          }, 
+          {
+            "start": 10, 
+            "end": 17, 
+            "value": "mexican", 
+            "entity": "cuisine"
+          }
+        ]
+      },
+      {
+        "text": "i am looking for an indian spot called olaolaolaolaolaola",
+        "intent": "restaurant_search",
+        "entities": [
+          {
+            "start": 20,
+            "end": 26,
+            "value": "indian",
+            "entity": "cuisine"
+          }
+        ]
+      },     {
+        "text": "search for restaurants",
+        "intent": "restaurant_search",
+        "entities": []
+      },
+      {
+        "text": "anywhere in the west",
+        "intent": "restaurant_search",
+        "entities": [
+          {
+            "start": 16,
+            "end": 20,
+            "value": "west",
+            "entity": "location"
+          }
+        ]
+      },
+      {
+        "text": "anywhere near 18328",
+        "intent": "restaurant_search",
+        "entities": [
+          {
+            "start": 14,
+            "end": 19,
+            "value": "18328",
+            "entity": "location"
+          }
+        ]
+      },
+      {
+        "text": "I am looking for asian fusion food",
+        "intent": "restaurant_search",
+        "entities": [
+          {
+            "start": 17,
+            "end": 29,
+            "value": "asian fusion",
+            "entity": "cuisine"
+          }
+        ]
+      },
+      {
+        "text": "I am looking a restaurant in 29432",
+        "intent": "restaurant_search",
+        "entities": [
+          {
+            "start": 29,
+            "end": 34,
+            "value": "29432",
+            "entity": "location"
+          }
+        ]
+      },
+      {
+        "text": "I am looking for mexican indian fusion",
+        "intent": "restaurant_search",
+        "entities": [
+          {
+            "start": 17,
+            "end": 38,
+            "value": "mexican indian fusion",
+            "entity": "cuisine"
+          }
+        ]
+      },
+      {
+        "text": "central indian restaurant",
+        "intent": "restaurant_search",
+        "entities": [
+          {
+            "start": 0,
+            "end": 7,
+            "value": "central",
+            "entity": "location"
+          },
+          {
+            "start": 8,
+            "end": 14,
+            "value": "indian",
+            "entity": "cuisine"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/data/examples/rasa/multiple_files_markdown/demo-rasa-affirm.md
+++ b/data/examples/rasa/multiple_files_markdown/demo-rasa-affirm.md
@@ -1,0 +1,12 @@
+## intent:affirm
+- yes
+- yep
+- yeah
+- indeed
+- that's right
+- ok
+- great
+- right, thank you
+- correct
+- great choice
+- sounds really good

--- a/data/examples/rasa/multiple_files_markdown/demo-rasa-goodbye.md
+++ b/data/examples/rasa/multiple_files_markdown/demo-rasa-goodbye.md
@@ -1,0 +1,9 @@
+## intent:goodbye
+- bye
+- goodbye
+- good bye
+- stop
+- end
+- farewell
+- Bye bye
+- have a good one

--- a/data/examples/rasa/multiple_files_markdown/demo-rasa-greet.md
+++ b/data/examples/rasa/multiple_files_markdown/demo-rasa-greet.md
@@ -1,0 +1,9 @@
+## intent:greet
+- hey
+- howdy
+- hey there
+- hello
+- hi
+- good morning
+- good evening
+- dear sir

--- a/data/examples/rasa/multiple_files_markdown/demo-rasa-restaurant_search.md
+++ b/data/examples/rasa/multiple_files_markdown/demo-rasa-restaurant_search.md
@@ -1,0 +1,25 @@
+## intent:restaurant_search
+- i'm looking for a place to eat
+- I want to grab lunch
+- I am searching for a dinner spot
+- i'm looking for a place in the [north](location) of town
+- show me [chinese](cuisine) restaurants
+- show me [chines](cuisine:chinese) restaurants
+- show me a [mexican](cuisine) place in the [centre](location)
+- i am looking for an [indian](cuisine) spot called olaolaolaolaolaola
+- search for restaurants
+- anywhere in the [west](location)
+- anywhere near [18328](location)
+- I am looking for [asian fusion](cuisine) food
+- I am looking a restaurant in [29432](location)
+- I am looking for [mexican indian fusion](cuisine)
+- [central](location) [indian](cuisine) restaurant
+
+## synonym:chinese
+- Chines
+- chines
+- Chinese
+
+## synonym:vegetarian
+- vegg
+- veggie

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -132,7 +132,7 @@ data
 :Type: ``str``
 :Examples: ``"data/example.json"``
 :Description:
-    Location of the training data.
+    Location of the training data. For JSON and markdown data, this can either be a single file or a directory containing multiple training data files.
 
 cors_origins
 ~~~~

--- a/docs/dataformat.rst
+++ b/docs/dataformat.rst
@@ -167,3 +167,15 @@ Alternatively training data can be used in the following markdown format (Regex 
 
     ## synonym:savings   <!-- synonyms, method 2 -->
     - pink pig
+
+Organization
+---------------------------
+
+The training data can either be stored in a single file or split into multiple files.
+For larger training examples splitting the training data into multiple files (e.g. one per intent) might be
+beneficial in terms of maintainability.
+
+Storing files with different file formats (e.g. markdown and JSON) in one directory is currently not supported.
+
+.. note::
+    Splitting the training data into multiple files currently only words for markdown and JSON data. For other file formats you have to use the single-file approach.

--- a/rasa_nlu/converters.py
+++ b/rasa_nlu/converters.py
@@ -246,26 +246,32 @@ def validate_rasa_nlu_data(data):
         raise e
 
 
-def load_rasa_data(filename):
-    # type: (Text) -> TrainingData
+def load_rasa_data(filenames):
+    # type: (List[Text]) -> TrainingData
     """Loads training data stored in the rasa NLU data format."""
 
-    data = _read_json_from_file(filename)
-    validate_rasa_nlu_data(data)
+    common = list()
+    intent = list()
+    entity = list()
+    regex_features = list()
+    synonyms = list()
+    for filename in filenames:
+        data = _read_json_from_file(filename)
+        validate_rasa_nlu_data(data)
 
-    common = data['rasa_nlu_data'].get("common_examples", list())
-    intent = data['rasa_nlu_data'].get("intent_examples", list())
-    entity = data['rasa_nlu_data'].get("entity_examples", list())
-    regex_features = data['rasa_nlu_data'].get("regex_features", list())
-    synonyms = data['rasa_nlu_data'].get("entity_synonyms", list())
+        common += data['rasa_nlu_data'].get("common_examples", list())
+        intent += data['rasa_nlu_data'].get("intent_examples", list())
+        entity += data['rasa_nlu_data'].get("entity_examples", list())
+        regex_features += data['rasa_nlu_data'].get("regex_features", list())
+        synonyms += data['rasa_nlu_data'].get("entity_synonyms", list())
 
     entity_synonyms = get_entity_synonyms_dict(synonyms)
 
     if intent or entity:
-        logger.warn("DEPRECATION warning: Data file contains 'intent_examples' "
+        logger.warn("DEPRECATION warning: Data file \"{}\" contains 'intent_examples' "
                     "or 'entity_examples' which will be "
                     "removed in the future. Consider putting all your examples "
-                    "into the 'common_examples' section.")
+                    "into the 'common_examples' section.".format(filename))
 
     all_examples = common + intent + entity
     training_examples = []
@@ -349,7 +355,7 @@ def load_data(resource_name, language='en', fformat=None):
     elif fformat == DIALOGFLOW_FILE_FORMAT:
         return load_dialogflow_data(files, language)
     elif fformat == RASA_FILE_FORMAT:
-        return load_rasa_data(files[0])
+        return load_rasa_data(files)
     elif fformat == MARKDOWN_FILE_FORMAT:
         return load_markdown_data(files[0])
     else:

--- a/rasa_nlu/converters.py
+++ b/rasa_nlu/converters.py
@@ -160,12 +160,16 @@ def load_wit_data(filename):
     return TrainingData(training_examples)
 
 
-def load_markdown_data(filename):
-    # type: (Text) -> TrainingData
+def load_markdown_data(filenames):
+    # type: (List[Text]) -> TrainingData
     """Loads training data stored in markdown data format."""
     from rasa_nlu.utils.md_to_json import MarkdownToJson
-    data = MarkdownToJson(filename)
-    return TrainingData(data.common_examples,
+
+    common_examples = list()
+    for filename in filenames:
+        data = MarkdownToJson(filename)
+        common_examples += data.common_examples
+    return TrainingData(common_examples,
                         get_entity_synonyms_dict(data.entity_synonyms))
 
 
@@ -357,7 +361,7 @@ def load_data(resource_name, language='en', fformat=None):
     elif fformat == RASA_FILE_FORMAT:
         return load_rasa_data(files)
     elif fformat == MARKDOWN_FILE_FORMAT:
-        return load_markdown_data(files[0])
+        return load_markdown_data(files)
     else:
         raise ValueError("unknown training file format : {} for "
                          "file {}".format(fformat, resource_name))

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -100,6 +100,28 @@ def test_markdown_data():
     assert td.entity_synonyms == {u'Chines': u'chinese', u'Chinese': u'chinese', u'chines': u'chinese',
                                   u'vegg': u'vegetarian', u'veggie': u'vegetarian'}
 
+def test_markdown_data_multiple():
+    # Load the reference data
+    td_reference = load_data('data/examples/rasa/demo-rasa.md')
+
+    # Load and check the multi-file data
+    td = load_data('data/examples/rasa/multiple_files_markdown')
+    assert len(td.sorted_entity_examples()) >= len([e for e in td.entity_examples if e.get("entities")])
+    assert len(td.sorted_intent_examples()) == len(td.intent_examples)
+    assert td.entity_synonyms == {u'Chines': u'chinese', u'Chinese': u'chinese', u'chines': u'chinese',
+                                  u'vegg': u'vegetarian', u'veggie': u'vegetarian'}
+
+    # Check the number of entries
+    assert td.num_entity_examples == td_reference.num_entity_examples
+    assert td.num_intent_examples == td_reference.num_intent_examples
+
+    # Compare the multi-file data with the reference
+    intents_reference  = [i.as_dict()['intent'] for i in td_reference.intent_examples]
+    examples_reference = [i.as_dict()['text']   for i in td_reference.intent_examples]
+    intents  = [i.as_dict()['intent'] for i in td.intent_examples]
+    examples = [i.as_dict()['text']   for i in td.intent_examples]
+    assert set(intents)  == set(intents_reference)
+    assert set(examples) == set(examples_reference)
 
 def test_repeated_entities():
     data = """

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -61,6 +61,30 @@ def test_rasa_data():
     assert td.entity_synonyms == {u'Chines': u'chinese', u'Chinese': u'chinese', u'chines': u'chinese',
                                   u'vegg': u'vegetarian', u'veggie': u'vegetarian'}
 
+def test_rasa_data_multiple():
+    # Load the reference data
+    td_reference = load_data('data/examples/rasa/demo-rasa.json')
+
+    # Load and check the multi-file data
+    td = load_data('data/examples/rasa/multiple_files_json')
+    assert td.entity_examples != []
+    assert td.intent_examples != []
+    assert len(td.sorted_entity_examples()) >= len([e for e in td.entity_examples if e.get("entities")])
+    assert len(td.sorted_intent_examples()) == len(td.intent_examples)
+    assert td.entity_synonyms == {u'Chines': u'chinese', u'Chinese': u'chinese', u'chines': u'chinese',
+                                  u'vegg': u'vegetarian', u'veggie': u'vegetarian'}
+
+    # Check the number of entries
+    assert td.num_entity_examples == td_reference.num_entity_examples
+    assert td.num_intent_examples == td_reference.num_intent_examples
+
+    # Compare the multi-file data with the reference
+    intents_reference  = [i.as_dict()['intent'] for i in td_reference.intent_examples]
+    examples_reference = [i.as_dict()['text']   for i in td_reference.intent_examples]
+    intents  = [i.as_dict()['intent'] for i in td.intent_examples]
+    examples = [i.as_dict()['text']   for i in td.intent_examples]
+    assert set(intents)  == set(intents_reference)
+    assert set(examples) == set(examples_reference)
 
 def test_dialogflow_data():
     td = load_data('data/examples/dialogflow/')


### PR DESCRIPTION
**Proposed changes**:
- allow splitting for JSON format
- allow splitting for markdown format

This fixes #180 at least for the Rasa-native formats.

Tested with split files using:
`converters.load_data(dir_containing_multiple_md_files).as_json()`
and
`converters.load_data(dir_containing_multiple_json_files).as_json()`

I did not touch the other formats as I cannot test those.

**Status (please check what you already did)**:
- [X] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
