### PR TITLE
NER evaluation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Added
 -----
 - non ascii character support for anything that gets json dumped (e.g.
   training data received over HTTP endpoint)
+- evaluation of entity extraction performance in ``evaluation.py``
 
 Changed
 -------

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -19,19 +19,19 @@ Furthermore, it creates a confusion matrix for you to see which intents are mist
 Entity Extraction
 -----------------
 For each entity extractor, the evaluation script logs its performance per entity type in your training data.
-So if you use :code:`ner_crf` and :code:`ner_duckling` in your pipeline, it will log two evaluation tables
+So if you use ``ner_crf`` and ``ner_duckling`` in your pipeline, it will log two evaluation tables
 containing recall, precision, and f1 measure for each entity type.
 
-In the case :code:`ner_duckling` we actually run the evaluation for each defined
-duckling dimension. If you use the :code:`time` and :code:`ordinal` dimensions, you would
-get two evaluation tables: one for :code:`ner_duckling (Time)` and one for
-:code:`ner_duckling (Ordinal)`.
+In the case ``ner_duckling`` we actually run the evaluation for each defined
+duckling dimension. If you use the ``time`` and ``ordinal`` dimensions, you would
+get two evaluation tables: one for ``ner_duckling (Time)`` and one for
+``ner_duckling (Ordinal)``.
 
-:code:`ner_synomyms` does not create an evaluation table, because it only changes the value of the found
+``ner_synomyms`` does not create an evaluation table, because it only changes the value of the found
 entities and does not find entity boundaries itself.
 
 Finally, keep in mind that entity types in your testing data have to match the output
-of the extraction components. This is particularly important for :code:`ner_duckling`, because it is not
+of the extraction components. This is particularly important for ``ner_duckling``, because it is not
 fitted to your training data.
 
 

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -1,0 +1,62 @@
+.. _section_evaluation:
+
+Evaluation
+==========
+
+The evaluation script `evaluate.py` allows you to test your models performance for intent classification and
+entity recognition. You invoke this script supplying test data, model, and config file arguments:
+
+.. code-block:: bash
+
+    evaluate.py -d data/my_test.json -m models/my_model -c my_nlu_config.json
+
+
+Intent Classification
+---------------------
+The evaluation script will log precision, recall, and f1 measure for each intent and once summarized for all.
+Furthermore, it creates a confusion matrix for you to see which intents are mistaken for which others.
+
+Entity Extraction
+-----------------
+For each entity extractor, the evaluation script logs its performance per entity type in your training data.
+So if you use :code:`ner_crf` and :code:`ner_duckling` in your pipeline, it will log two evaluation tables
+containing recall, precision, and f1 measure for each entity type.
+
+In the case :code:`ner_duckling` we actually run the evaluation for each defined
+duckling dimension. If you use the :code:`time` and :code:`ordinal` dimensions, you would
+get two evaluation tables: one for :code:`ner_duckling (Time)` and one for
+:code:`ner_duckling (Ordinal)`.
+
+:code:`ner_synomyms` does not create an evaluation table, because it only changes the value of the found
+entities and does not find entity boundaries itself.
+
+Finally, keep in mind that entity types in your testing data have to match the output
+of the extraction components. This is particularly important for :code:`ner_duckling`, because it is not
+fitted to your training data.
+
+
+Entity Scoring
+^^^^^^^^^^^^^^
+To evaluate entity extraction we apply a simple tag-based approach. We don't consider BILOU tags, but only the
+entity type tags on a per token basis. For location entity like "near Alexanderplatz" we
+expect the labels "LOC" "LOC" instead of the BILOU-based "B-LOC" "L-LOC". Our approach is more lenient
+when it comes to evaluation, as it rewards partial extraction and does not punish the splitting of entities.
+For example, the given the aforementioned entity "near Alexanderplatz" and a system that extracts
+"Alexanderplatz", this reward the extraction of "Alexanderplatz" and punish the missed out word "near".
+The BILOU-based approach, however, would label this as a complete failure since it expects Alexanderplatz
+to be labeled as a last token in an entity (L-LOC) instead of a single token entity (U-LOC). Also note,
+a splitted extraction of "near" and "Alexanderplatz" would get full scores on our approach and zero on the
+BILOU-based one.
+
+Here's a comparison between both different scoring mechanisms for the phrase "near Alexanderplatz tonight":
+
+==================================================  ========================  ===========================
+extracted                                           Simple tags (score)       BILOU tags (score)
+==================================================  ========================  ===========================
+[near Alexanderplatz](loc) [tonight](time)          loc loc time (3)          B-loc L-loc U-time (3)
+[near](loc) [Alexanderplatz](loc) [tonight](time)   loc loc time (3)          U-loc U-loc U-time (1)
+near [Alexanderplatz](loc) [tonight](time)          O   loc time (2)          O     U-loc U-time (1)
+[near](loc) Alexanderplatz [tonight](time)          loc O   time (2)          U-loc O     U-time (1)
+[near Alexanderplatz tonight](loc)                  loc loc loc  (2)          B-loc I-loc L-loc  (1)
+==================================================  ========================  ===========================
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,6 +90,7 @@ rasa is a set of tools for building more advanced bots, developed by `Rasa <http
    persist
    languages
    pipeline
+   evaluation
    faq
    migrations
    license

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -7,9 +7,12 @@ import argparse
 import itertools
 import logging
 import os
+import numpy as np
+import copy
 
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
+from collections import defaultdict
 
 from rasa_nlu.config import RasaNLUConfig
 from rasa_nlu.converters import load_data
@@ -17,6 +20,8 @@ from rasa_nlu.model import Interpreter
 from rasa_nlu.model import Metadata
 
 logger = logging.getLogger(__name__)
+
+duckling_extractors = {"ner_duckling", "ner_duckling_http"}
 
 
 def create_argparser():
@@ -83,32 +88,200 @@ def log_evaluation_table(test_y, preds):
     logger.info("Classification report: \n{}".format(report))
 
 
-def run_intent_evaluation(config, model_path, component_builder=None):
+def evaluate_intents(targets, predictions):
     from sklearn.metrics import confusion_matrix
     from sklearn.utils.multiclass import unique_labels
 
-    # get the metadata config from the package data
-    test_data = load_data(config['data'], config['language'])
-    interpreter = Interpreter.load(model_path, config, component_builder)
+    log_evaluation_table(targets, predictions)
 
-    test_y = [e.get("intent") for e in test_data.training_examples]
-
-    preds = []
-    for e in test_data.training_examples:
-        res = interpreter.parse(e.text)
-        if res.get('intent'):
-            preds.append(res['intent'].get('name'))
-        else:
-            preds.append(None)
-
-    log_evaluation_table(test_y, preds)
-
-    cnf_matrix = confusion_matrix(test_y, preds)
-    plot_confusion_matrix(cnf_matrix, classes=unique_labels(test_y, preds),
+    cnf_matrix = confusion_matrix(targets, predictions)
+    plot_confusion_matrix(cnf_matrix, classes=unique_labels(targets, predictions),
                           title='Intent Confusion matrix')
 
     plt.show()
-    return
+
+def evaluate_entities(targets, predictions, tokens, extractors):
+
+    aligned_predictions = []
+    for ts, ps, tks in zip(targets, predictions, tokens):
+        aligned_predictions.append(align_entity_predictions(ts, ps, tks, extractors))
+
+    merged_targets = np.array(list(itertools.chain(*[ap["target_labels"]
+                                                            for ap in aligned_predictions])))
+
+    has_entities = merged_targets != "O"
+
+    for extractor in extractors:
+        merged_predictions = np.array(list(itertools.chain(*[ap["extractor_labels"][extractor]
+                                                            for ap in aligned_predictions])))
+        logger.info("Eval Entities: %s" % extractor)
+        # log_evaluation_table(merged_targets[has_entities], merged_predictions[has_entities])
+        log_evaluation_table(merged_targets, merged_predictions)
+
+def is_token_within_entity(token, entity):
+    """
+    Checks if a token is within the boundaries of an entity
+    """
+    return determine_intersection(token, entity) == len(token.text)
+
+def does_token_cross_borders(token, entity):
+    """
+    Checks if a token crosses the boundaries of an entity
+    """
+    num_intersect = determine_intersection(token, entity)
+    return num_intersect > 0 and num_intersect < len(token.text)
+
+def determine_intersection(token, entity):
+    """
+    Calculates how many characters a given token and entity share
+    """
+    pos_token = set(range(token.offset, token.end))
+    pos_entity = set(range(entity["start"], entity["end"]))
+    return len(pos_token.intersection(pos_entity))
+
+def do_entities_overlap(entities):
+    """
+    Checks if entities overlap, i.e. cross each others start and end boundaries
+    :param entities: list of entities
+    :return: boolean
+    """
+    sorted_entities = sorted(entities, key = lambda e: e["start"])
+    for i in range(len(sorted_entities) - 1):
+        if sorted_entities[i+1]["start"] < sorted_entities[i]["end"]\
+                and sorted_entities[i+1]["entity"] != sorted_entities[i]["entity"]:
+            return True
+
+    return False
+
+def determine_token_labels(token, entities):
+    """
+    Determines the token label given entities that do not overlap
+    :param token: a single token
+    :param entities: entities found by a single extractor
+    :return: token label string (entity type)
+    """
+    if len(entities) == 0:
+        return "O"
+
+    if do_entities_overlap(entities):
+        raise ValueError("The possible entities should not overlap")
+
+    candidates = []
+    for e in entities:
+        if is_token_within_entity(token, e):
+            candidates.append(e)
+        elif does_token_cross_borders(token, e):
+            candidates.append(e)
+            logger.debug("Token boundary error for token %s(%d, %d) and entity %s" % (token.text, token.offset, token.end, e))
+
+
+    if len(candidates) == 0:
+        return "O"
+    elif len(candidates) == 1:
+        return candidates[0]["entity"]
+    else:
+        best_fit = np.argmax([determine_intersection(token, c) for c in candidates])
+        return candidates[best_fit]["entity"]
+
+def align_entity_predictions(targets, predictions, tokens, used_extractors):
+    """
+    Determines for every token the true label based on the prediction targets and
+    the label assigned by each single extractor
+    :param targets: list of target entities
+    :param predictions: list of predicted entities
+    :param tokens: message tokens as used by the extractors
+    :param used_extractors: the extractors that should be considered
+    :return: dictionary containing the true token labels and token labels from the extractors
+    """
+    true_token_labels = []
+    entities_by_extractors = {extractor: [] for extractor in used_extractors}
+    for p in predictions:
+        entities_by_extractors[p["extractor"]].append(p)
+    extractor_labels = defaultdict(list)
+    for t in tokens:
+        true_token_labels.append(determine_token_labels(t, targets))
+        for extractor, entities in entities_by_extractors.items():
+            extractor_labels[extractor].append(determine_token_labels(t, entities))
+
+
+    return {"target_labels": true_token_labels, "extractor_labels": dict(extractor_labels)}
+
+
+def get_targets(test_data):
+    """
+    Extracts targets from the test data
+    """
+    intent_targets = [e.get("intent") for e in test_data.training_examples]
+    entity_targets = [e.get("entities", []) for e in test_data.training_examples]
+
+    return intent_targets, entity_targets
+
+
+def get_predictions(interpreter, test_data):
+    """
+    Runs the model for the test set and extracts predictions and tokens
+    """
+    intent_predictions, entity_predictions, tokens = [], [], []
+    for e in test_data.training_examples:
+        res = interpreter.parse(e.text, only_output_properties=False)
+        intent_predictions.append(res['intent'].get('name') if 'intent' in res else None)
+        entity_predictions.append(res['entities'] if 'entities' in res else [])
+        tokens.append(res["tokens"])
+    return intent_predictions, entity_predictions, tokens
+
+def get_entity_extractors(interpreter):
+    """
+    Finds the names of entity extractors used by the interpreter
+    Processors are removed since they do not detect the boundaries themselves
+    """
+    extractors = set([c.name for c in interpreter.pipeline if "entities" in c.provides])
+    processors = {"ner_synonyms"}
+    return extractors - processors
+
+def combine_extractor_and_dim(extractor, dim):
+    return "%s (%s)" % (extractor, dim)
+
+def patch_duckling_extractors(interpreter, extractors):
+    """
+    Removes the basic duckling extractor from the set of extractors and adds dimension-suffixed ones
+    """
+    patched_extractors = extractors.copy()
+    for extractor in duckling_extractors:
+        if extractor in patched_extractors:
+            duckling_component = [c for c in interpreter.pipeline if c.name == extractor][0]
+            patched_extractors.remove(extractor)
+            for dim in duckling_component.dimensions:
+                patched_extractors.add(combine_extractor_and_dim(extractor, dim))
+    return patched_extractors
+
+
+def patch_duckling_entities(entity_predictions):
+    """
+    Adds the duckling dimension as a suffix to the extractor name to make sure
+    there only is one prediction per token per extractor name
+    """
+    patched_entity_predictions = copy.deepcopy(entity_predictions)
+    for entities in patched_entity_predictions:
+        for e in entities:
+            if e["extractor"] in duckling_extractors:
+                e["extractor"] = combine_extractor_and_dim(e["extractor"], e["entity"])
+    return patched_entity_predictions
+
+
+def run_evaluation(config, model_path, component_builder=None):
+    # get the metadata config from the package data
+    test_data = load_data(config['data'], config['language'])
+    interpreter = Interpreter.load(model_path, config, component_builder)
+    intent_targets, entity_targets = get_targets(test_data)
+    intent_predictions, entity_predictions, tokens = get_predictions(interpreter, test_data)
+    extractors = get_entity_extractors(interpreter)
+
+    if extractors.intersection(duckling_extractors):
+        entity_predictions = patch_duckling_entities(entity_predictions)
+        extractors = patch_duckling_extractors(interpreter, extractors)
+
+    evaluate_intents(intent_targets, intent_predictions)
+    evaluate_entities(entity_targets, entity_predictions, tokens, extractors)
 
 
 if __name__ == '__main__':
@@ -117,5 +290,5 @@ if __name__ == '__main__':
     nlu_config = RasaNLUConfig(args.config, os.environ, vars(args))
     logging.basicConfig(level=nlu_config['log_level'])
 
-    run_intent_evaluation(nlu_config, args.model)
+    run_evaluation(nlu_config, args.model)
     logger.info("Finished evaluation")

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -27,7 +27,7 @@ entity_processors = {"ner_synonyms"}
 
 def create_argparser():
     parser = argparse.ArgumentParser(
-        description='evaluate a trained Rasa NLU pipeline')
+            description='evaluate a trained Rasa NLU pipeline')
 
     parser.add_argument('-d', '--data', default=None,
                         help="file containing evaluation data")
@@ -99,8 +99,8 @@ def evaluate_intents(targets, predictions):
     mask = targets != ""
     targets = targets[mask]
     predictions = np.array(predictions)[mask]
-    logger.info("Intent Evaluation: Only considering those %d examples that "
-                "have a defined intent out of %d examples" % (targets.size, num_examples))
+    logger.info("Intent Evaluation: Only considering those {} examples that "
+                "have a defined intent out of {} examples".format(targets.size, num_examples))
     log_evaluation_table(targets, predictions)
 
     cnf_matrix = confusion_matrix(targets, predictions)
@@ -121,7 +121,7 @@ def evaluate_entities(targets, predictions, tokens, extractors):
     for extractor in extractors:
         merged_predictions = np.array(list(itertools.chain(*[ap["extractor_labels"][extractor]
                                                              for ap in aligned_predictions])))
-        logger.info("Eval Entities: %s" % extractor)
+        logger.info("Evaluation for entity extractor: {}".format(extractor))
         log_evaluation_table(merged_targets, merged_predictions)
 
 
@@ -178,7 +178,8 @@ def find_intersecting_entites(token, entities):
         elif does_token_cross_borders(token, e):
             candidates.append(e)
             logger.debug(
-                "Token boundary error for token %s(%d, %d) and entity %s" % (token.text, token.offset, token.end, e))
+                    "Token boundary error for token {}({}, {}) and entity {}".format(
+                            token.text, token.offset, token.end, e))
     return candidates
 
 
@@ -282,7 +283,7 @@ def get_entity_extractors(interpreter):
 
 def combine_extractor_and_dimension_name(extractor, dim):
     """Joins the duckling extractor name with a dimension's name"""
-    return "%s (%s)" % (extractor, dim)
+    return "{} ({})".format(extractor, dim)
 
 
 def get_duckling_dimensions(interpreter, duckling_extractor_name):

--- a/rasa_nlu/extractors/crf_entity_extractor.py
+++ b/rasa_nlu/extractors/crf_entity_extractor.py
@@ -163,7 +163,7 @@ class CRFEntityExtractor(EntityExtractor):
                     finished = False
                     while not finished:
                         if len(entities) > ent_word_idx and \
-                                        entities[ent_word_idx][2:] != entity[2:]:
+                                entities[ent_word_idx][2:] != entity[2:]:
                             # words are not tagged the same entity class
                             logger.debug(
                                     "Inconsistent BILOU tagging found, B- tag, "
@@ -211,10 +211,10 @@ class CRFEntityExtractor(EntityExtractor):
 
     @classmethod
     def load(cls,
-             model_dir,     # type: Text
-             model_metadata,    # type: Metadata
+             model_dir,  # type: Text
+             model_metadata,  # type: Metadata
              cached_component,  # type: Optional[CRFEntityExtractor]
-             **kwargs   # type: **Any
+             **kwargs  # type: **Any
              ):
         # type: (...) -> CRFEntityExtractor
         from sklearn.externals import joblib
@@ -298,7 +298,7 @@ class CRFEntityExtractor(EntityExtractor):
                         entity.startswith('I-') or \
                         entity.startswith('U-') or \
                         entity.startswith('L-'):
-                    ents[i] = entity[2:]        # removes the BILOU tags
+                    ents[i] = entity[2:]  # removes the BILOU tags
 
         return self._from_text_to_crf(message, ents)
 
@@ -334,40 +334,3 @@ class CRFEntityExtractor(EntityExtractor):
                 all_possible_transitions=True  # include transitions that are possible, but not observed
         )
         self.ent_tagger.fit(X_train, y_train)
-
-    def _test_model(self, df_test):
-        # type: (List[List[Tuple[Text, Text, Text, Text]]]) -> None
-
-        X_test = [self._sentence_to_features(sent) for sent in df_test]
-        y_test = [self._sentence_to_labels(sent) for sent in df_test]
-        y_pred = [self.ent_tagger.predict_single(xseq) for xseq in X_test]
-        print(bio_classification_report(y_test, y_pred))
-
-
-def bio_classification_report(y_true, y_pred):
-    """Evaluates entity extraction accuracy.
-
-    Classification report for a list of BIO-encoded sequences.
-    It computes token-level metrics and discards "O" labels.
-    Note that it requires scikit-learn 0.15+ (or a version from github master)
-    to calculate averages properly!
-    Taken from https://github.com/scrapinghub/python-crfsuite/blob/master/examples/CoNLL%202002.ipynb
-    """
-    from sklearn.preprocessing import LabelBinarizer
-    from itertools import chain
-    from sklearn.metrics import classification_report
-
-    lb = LabelBinarizer()
-    y_true_combined = lb.fit_transform(list(chain.from_iterable(y_true)))
-    y_pred_combined = lb.transform(list(chain.from_iterable(y_pred)))
-
-    tagset = set(lb.classes_) - {'O'}
-    tagset = sorted(tagset, key=lambda tag: tag.split('-', 1)[::-1])
-    class_indices = {cls: idx for idx, cls in enumerate(lb.classes_)}
-
-    return classification_report(
-            y_true_combined,
-            y_pred_combined,
-            labels=[class_indices[cls] for cls in tagset],
-            target_names=tagset,
-    )

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -274,7 +274,7 @@ class Interpreter(object):
         self.context = context if context is not None else {}
         self.model_metadata = model_metadata
 
-    def parse(self, text, time=None):
+    def parse(self, text, time=None, only_output_properties = True):
         # type: (Text) -> Dict[Text, Any]
         """Parse the input text, classify it and return pipeline result.
 
@@ -295,5 +295,5 @@ class Interpreter(object):
             component.process(message, **self.context)
 
         output = self.default_output_attributes()
-        output.update(message.as_dict(only_output_properties=True))
+        output.update(message.as_dict(only_output_properties=only_output_properties))
         return output

--- a/tests/evaluation.py
+++ b/tests/evaluation.py
@@ -1,0 +1,128 @@
+# coding=utf-8
+import pytest
+import logging
+
+from rasa_nlu.evaluate import is_token_within_entity
+from rasa_nlu.evaluate import does_token_cross_borders
+from rasa_nlu.evaluate import align_entity_predictions
+from rasa_nlu.evaluate import determine_intersection
+from rasa_nlu.tokenizers import Token
+
+logging.basicConfig(level="DEBUG")
+
+# Chinese Example
+# "对面食过敏" -> To be allergic to wheat-based food
+CH_wrong_segmentation = [Token(u"对面", 0), Token(u"食", 2), Token(u"过敏", 3)]  # opposite, food, allergy
+CH_correct_segmentation = [Token(u"对", 0), Token(u"面食", 1), Token(u"过敏", 3)]  # towards, wheat-based food, allergy
+CH_wrong_entity = {
+    "start": 0,
+    "end": 2,
+    "value": u"对面",
+    "entity": "direction"
+
+}
+CH_correct_entity = {
+    "start": 1,
+    "end": 3,
+    "value": u"面食",
+    "entity": "food_type"
+}
+
+#EN example
+#"Hey Robot, I would like to eat pizza near Alexanderplatz tonight"
+EN_indices = [0, 4, 9, 11, 13, 19, 24, 27, 31, 37, 42, 57]
+EN_tokens = ["Hey", "Robot", ",", "I", "would", "like", "to", "eat", "pizza", "near", "Alexanderplatz", "tonight"]
+EN_tokens = [Token(t, i) for t, i in zip(EN_tokens, EN_indices)]
+
+EN_targets = [
+    {
+       "start": 31,
+        "end": 36,
+        "value": "pizza",
+        "entity": "food"
+    },
+    {
+        "start": 37,
+        "end": 56,
+        "value": "near Alexanderplatz",
+        "entity": "location"
+    },
+    {
+        "start": 57,
+        "end": 64,
+        "value": "tonight",
+        "entity": "datetime"
+    }
+]
+
+EN_predicted = [
+    {
+        "start": 4,
+        "end": 9,
+        "value": "Robot",
+        "entity": "person",
+        "extractor": "A"
+    },
+    {
+        "start": 31,
+        "end": 36,
+        "value": "pizza",
+        "entity": "food",
+        "extractor": "A"
+    },
+    {
+        "start": 42,
+        "end": 56,
+        "value": "Alexanderplatz",
+        "entity": "location",
+        "extractor": "A"
+    },
+    {
+        "start": 42,
+        "end": 64,
+        "value": "Alexanderplatz tonight",
+        "entity": "movie",
+        "extractor": "B"
+    }
+]
+
+def test_token_entity_intersection():
+    # included
+    assert determine_intersection(CH_correct_segmentation[1], CH_correct_entity) == len(CH_correct_segmentation[1].text)
+
+    # completely outside
+    assert determine_intersection(CH_correct_segmentation[2], CH_correct_entity) == 0
+
+    # border crossing
+    assert determine_intersection(CH_correct_segmentation[1], CH_wrong_entity) == 1
+
+def test_token_entity_boundaries():
+    #smaller and included
+    assert is_token_within_entity(CH_wrong_segmentation[1], CH_correct_entity) == True
+    assert does_token_cross_borders(CH_wrong_segmentation[1], CH_correct_entity) == False
+
+    # exact match
+    assert is_token_within_entity(CH_correct_segmentation[1], CH_correct_entity) == True
+    assert does_token_cross_borders(CH_correct_segmentation[1], CH_correct_entity) == False
+
+    # completely outside
+    assert is_token_within_entity(CH_correct_segmentation[0], CH_correct_entity) == False
+    assert does_token_cross_borders(CH_correct_segmentation[0], CH_correct_entity) == False
+
+    # border crossing
+    assert is_token_within_entity(CH_wrong_segmentation[0], CH_correct_entity) == False
+    assert does_token_cross_borders(CH_wrong_segmentation[0], CH_correct_entity) == True
+
+
+def test_evaluate_entities():
+    result = align_entity_predictions(EN_targets, EN_predicted, EN_tokens, ["A", "B"])
+    assert result == {
+        "target_labels": ["O", "O", "O", "O", "O", "O", "O", "O", "food", "location", "location", "datetime"],
+        "extractor_labels": {
+            "A": ["O", "person", "O", "O", "O", "O", "O", "O", "food", "O", "location", "O"],
+            "B": ["O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "movie", "movie"]
+        }
+    }, "Wrong entity prediction alignment"
+
+
+

--- a/tests/evaluation.py
+++ b/tests/evaluation.py
@@ -1,4 +1,9 @@
 # coding=utf-8
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import pytest
 import logging
 
@@ -12,31 +17,31 @@ logging.basicConfig(level="DEBUG")
 
 # Chinese Example
 # "对面食过敏" -> To be allergic to wheat-based food
-CH_wrong_segmentation = [Token(u"对面", 0), Token(u"食", 2), Token(u"过敏", 3)]  # opposite, food, allergy
-CH_correct_segmentation = [Token(u"对", 0), Token(u"面食", 1), Token(u"过敏", 3)]  # towards, wheat-based food, allergy
+CH_wrong_segmentation = [Token("对面", 0), Token("食", 2), Token("过敏", 3)]  # opposite, food, allergy
+CH_correct_segmentation = [Token("对", 0), Token("面食", 1), Token("过敏", 3)]  # towards, wheat-based food, allergy
 CH_wrong_entity = {
     "start": 0,
     "end": 2,
-    "value": u"对面",
+    "value": "对面",
     "entity": "direction"
 
 }
 CH_correct_entity = {
     "start": 1,
     "end": 3,
-    "value": u"面食",
+    "value": "面食",
     "entity": "food_type"
 }
 
-#EN example
-#"Hey Robot, I would like to eat pizza near Alexanderplatz tonight"
+# EN example
+# "Hey Robot, I would like to eat pizza near Alexanderplatz tonight"
 EN_indices = [0, 4, 9, 11, 13, 19, 24, 27, 31, 37, 42, 57]
 EN_tokens = ["Hey", "Robot", ",", "I", "would", "like", "to", "eat", "pizza", "near", "Alexanderplatz", "tonight"]
 EN_tokens = [Token(t, i) for t, i in zip(EN_tokens, EN_indices)]
 
 EN_targets = [
     {
-       "start": 31,
+        "start": 31,
         "end": 36,
         "value": "pizza",
         "entity": "food"
@@ -86,6 +91,7 @@ EN_predicted = [
     }
 ]
 
+
 def test_token_entity_intersection():
     # included
     assert determine_intersection(CH_correct_segmentation[1], CH_correct_entity) == len(CH_correct_segmentation[1].text)
@@ -96,8 +102,9 @@ def test_token_entity_intersection():
     # border crossing
     assert determine_intersection(CH_correct_segmentation[1], CH_wrong_entity) == 1
 
+
 def test_token_entity_boundaries():
-    #smaller and included
+    # smaller and included
     assert is_token_within_entity(CH_wrong_segmentation[1], CH_correct_entity) == True
     assert does_token_cross_borders(CH_wrong_segmentation[1], CH_correct_entity) == False
 
@@ -115,7 +122,8 @@ def test_token_entity_boundaries():
 
 
 def test_evaluate_entities():
-    result = align_entity_predictions(EN_targets, EN_predicted, EN_tokens, ["A", "B"])
+    mock_extractors = ["A", "B"]
+    result = align_entity_predictions(EN_targets, EN_predicted, EN_tokens, mock_extractors)
     assert result == {
         "target_labels": ["O", "O", "O", "O", "O", "O", "O", "O", "food", "location", "location", "datetime"],
         "extractor_labels": {
@@ -123,6 +131,3 @@ def test_evaluate_entities():
             "B": ["O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "movie", "movie"]
         }
     }, "Wrong entity prediction alignment"
-
-
-


### PR DESCRIPTION
**Proposed changes**:
1. Extended evaluation script to measure entity extraction performance. I used a simple tag-based approach, as opposed to using BILOU tags, i.e. we only have entity tags like "LOC" instead of "B-LOC", "I-LOC" etc. This approach is a tad more lenient when it comes to evaluation since it also rewards partial extraction and does not punish the split of an entity. It is debatable which approach is better, but partial eval might be a tad more realistic. For example, the given the entity "near Alexanderplatz" and a system that extracts "Alexanderplatz", the simple tags would reward the extraction of Alexanderplatz and punish the missed out word "near". The BILOU tags, however, would evaluate it as a complete failure since "Alexanderplatz" should be an inside- or a closing tag instead of a single tag. However, if we had something like "Madison Square Garden" and extract only "Madison Square" or "Square Garden" or split it into two entities "Madison" AND "Square Garden" we would also give partial, or in the latter case even full score (given correct type), although it might be misleading. 

2. Allow the usage of no-intent examples in testing data

**Open Questions**
1. The eval script writes out a confusion matrix for every extractor involved. However, the duckling dimension names might not overlap with the entity type names that the developer has chosen. For example, the training data might contain the labels for times as "datetime" while duckling uses the entity type "time". I wonder if Rasa NLU should support some name mapping in the pipeline from duckling dimensions to other names, or if this is something that is only required in the evaluation

2. So far there is no documentation for the evaluation. Should I write one from scratch or should we leave it like this for now?

3. Should we split the `data` config variable into `training_data` and `test_data`? I made the mistake for a while training and evaluating both on the same data. Changing the config between training and testing was something that slipped my mind, so I am wondering if the split would be better from a UX perspective.

4. The ner_crf component also has a few testing methods, I would remove these. Any objections?

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
