### PR TITLE
Added Support for Asterisks in Markdown Training Files

### DIFF
--- a/data/test/demo-rasa-small.md
+++ b/data/test/demo-rasa-small.md
@@ -1,0 +1,64 @@
+## intent:affirm
+
+* yes
+* yep
+* yeah
+* indeed
+* that's right
+* ok
+* great
+* right, thank you
+* correct
+* great choice
+* sounds really good
+
+## intent:goodbye
+
+* bye
+* goodbye
+* good bye
+* stop
+* end
+* farewell
+* Bye bye
+* have a good one
+
+## intent:greet
+
+* hey
+* howdy
+* hey there
+* hello
+* hi
+* good morning
+* good evening
+* dear sir
+
+## intent:restaurant_search
+
+* i'm looking for a place to eat
+* I want to grab lunch
+* I am searching for a dinner spot
+* i'm looking for a place in the [north](location) of town
+* show me [chinese](cuisine) restaurants
+* show me [chines](cuisine:chinese) restaurants
+* show me a [mexican](cuisine) place in the [centre](location)
+* i am looking for an [indian](cuisine) spot called olaolaolaolaolaola
+* search for restaurants
+* anywhere in the [west](location)
+* anywhere near [18328](location)
+* I am looking for [asian fusion](cuisine) food
+* I am looking a restaurant in [29432](location)
+* I am looking for [mexican indian fusion](cuisine)
+* [central](location) [indian](cuisine) restaurant
+
+## synonym:chinese
+
+* Chines
+* chines
+* Chinese
+
+## synonym:vegetarian
+
+* vegg
+* veggie

--- a/docs/dataformat.rst
+++ b/docs/dataformat.rst
@@ -37,13 +37,13 @@ That way you can map syonyms, or misspellings, to the same ``value``.
 .. code-block:: json
 
     {
-      "text": "show me chinese restaurants", 
-      "intent": "restaurant_search", 
+      "text": "show me chinese restaurants",
+      "intent": "restaurant_search",
       "entities": [
         {
-          "start": 8, 
-          "end": 15, 
-          "value": "chinese", 
+          "start": 8,
+          "end": 15,
+          "value": "chinese",
           "entity": "cuisine"
         }
       ]
@@ -104,10 +104,10 @@ Alternatively, you can add an "entity_synonyms" array to define several synonyms
       ]
     }
   }
-  
+
 .. note::
     Please note that adding synonyms using the above format does not improve the model's classification of those entities.
-    **Entities must be properly classified before they can be replaced with the synonym value.** 
+    **Entities must be properly classified before they can be replaced with the synonym value.**
 
 
 Regular Expression Features
@@ -152,7 +152,7 @@ for these extractors. Currently, all intent classifiers make use of available re
 Markdown Format
 ---------------------------
 
-Alternatively training data can be used in the following markdown format (Regex features not supported yet):
+Alternatively training data can be used in the following markdown format (Regex features not supported yet). Examples are listed using the unordered list syntax, e.g. minus ``-`` or asterisk ``*``:
 
 .. code-block:: markdown
 

--- a/rasa_nlu/utils/md_to_json.py
+++ b/rasa_nlu/utils/md_to_json.py
@@ -14,16 +14,16 @@ ent_regex_with_value = re.compile(r'\[(?P<synonym>[^\]]+)'
                                   r'(?P<value>[^)]+)\)')  # [open](open:1)
 intent_regex = re.compile(r'##\s*intent:(.+)')
 synonym_regex = re.compile(r'##\s*synonym:(.+)')
-example_regex = re.compile(r'\s*-\s*(.+)')
-comment_regex = re.compile(r'<!--[\s\S]*?--!*>',re.MULTILINE)
+example_regex = re.compile(r'\s*[-\*]\s*(.+)')
+comment_regex = re.compile(r'<!--[\s\S]*?--!*>', re.MULTILINE)
 
 INTENT_PARSING_STATE = "intent"
 SYNONYM_PARSING_STATE = "synonym"
 
-def strip_comments(comment_regex,text): 
-    """ Removes comments defined by `comment_regex` from `text`. """ 
-    text = re.sub(comment_regex,'',text)
-    text = text.splitlines()# Split into lines
+def strip_comments(comment_regex, text):
+    """ Removes comments defined by `comment_regex` from `text`. """
+    text = re.sub(comment_regex, '', text)
+    text = text.splitlines()  # Split into lines
     return text
 
 
@@ -42,10 +42,10 @@ class MarkdownToJson(object):
         """Parse the content of the actual .md file."""
 
         with io.open(self.file_name, 'rU', encoding="utf-8-sig") as f:
-            f_com_rmved = strip_comments(comment_regex,f.read())# Strip comments
+            f_com_rmved = strip_comments(comment_regex, f.read())  # Strip comments
             for row in f_com_rmved:
                 # Remove white-space which may have crept in due to comments
-                row = row.strip() 
+                row = row.strip()
                 intent_match = re.search(intent_regex, row)
                 if intent_match is not None:
                     self._set_current_state(

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -76,6 +76,8 @@ def test_markdown_data():
     assert td.entity_synonyms == {u'Chines': u'chinese', u'Chinese': u'chinese', u'chines': u'chinese',
                                   u'vegg': u'vegetarian', u'veggie': u'vegetarian'}
 
+
+def test_markdown_data_asterisks_format():
     td = load_data('data/test/demo-rasa-small.md')
     assert len(td.sorted_entity_examples()) >= len([e for e in td.entity_examples if e.get("entities")])
     assert len(td.sorted_intent_examples()) == len(td.intent_examples)

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -76,6 +76,12 @@ def test_markdown_data():
     assert td.entity_synonyms == {u'Chines': u'chinese', u'Chinese': u'chinese', u'chines': u'chinese',
                                   u'vegg': u'vegetarian', u'veggie': u'vegetarian'}
 
+    td = load_data('data/test/demo-rasa-small.md')
+    assert len(td.sorted_entity_examples()) >= len([e for e in td.entity_examples if e.get("entities")])
+    assert len(td.sorted_intent_examples()) == len(td.intent_examples)
+    assert td.entity_synonyms == {u'Chines': u'chinese', u'Chinese': u'chinese', u'chines': u'chinese',
+                                  u'vegg': u'vegetarian', u'veggie': u'vegetarian'}
+
 
 def test_repeated_entities():
     data = """


### PR DESCRIPTION
**Proposed changes**:
- Since the training data format already supports markdown, I added support for listing examples as [unordered lists](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) using asterisks `*` instead of minus `-` symbols.
- Removed some PEP8 errors from `rasa_nlu/utils/md_to_json.py`

E.g.
```
## intent:affirm
* yes
* yep
* yeah
```
**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
