### PR TITLE
remove -e . from requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
 - source activate test-environment
 - pip install git+https://github.com/tmbo/MITIE.git
 - pip install -r alt_requirements/requirements_dev.txt
+- pip install -e .
 - pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-1.2.0/en_core_web_sm-1.2.0.tar.gz
   --no-cache-dir > jnk
 - python -m spacy link en_core_web_sm en

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Added
 
 Changed
 -------
+- removed ``-e .`` from requirements files - if you want to install the app use ``pip install -e .``
 
 Fixed
 -----

--- a/README.md
+++ b/README.md
@@ -132,11 +132,13 @@ From github:
 git clone git@github.com:RasaHQ/rasa_nlu.git
 cd rasa_nlu
 pip install -r requirements.txt
+pip install -e .
 ```
 
 For local development make sure you install the development requirements:
 ```
 pip install -r alt_requirements/requirements_dev.txt
+pip install -e .
 ```
 
 To test the installation use (this will run a very stupid default model. you need to [train your own model](https://rasahq.github.io/rasa_nlu/tutorial.html) to do something useful!):
@@ -167,11 +169,20 @@ In order to use the Spacy or Mitie backends make sure you have one of their pret
 python -m spacy download en
 ```
 
+To download the Mitie model run and place it in a location that you can 
+reference in your configuration during model training:
 ```
 wget https://github.com/mit-nlp/MITIE/releases/download/v0.4/MITIE-models-v0.2.tar.bz2
 tar jxf MITIE-models-v0.2.tar.bz2
-cp MITIE-models/english/total_word_feature_extractor.dat <rasa_nlu_root>/data/
 ```
+
+If you want to run the tests, you need to copy the model into the Rasa folder:
+
+```
+cp MITIE-models/english/total_word_feature_extractor.dat RASA_NLU_ROOT/data/
+``` 
+
+Where `RASA_NLU_ROOT` points to your Rasa installation directory.
 
 # Development Internals
 

--- a/alt_requirements/requirements_dev.txt
+++ b/alt_requirements/requirements_dev.txt
@@ -28,4 +28,3 @@ sphinx-autobuild==0.6.0
 sphinxcontrib-versioning==2.2.1
 nbsphinx==0.2.13
 -e git://github.com/RasaHQ/sphinx_rtd_theme.git#egg=sphinx_rtd_theme
--e .

--- a/docker/Dockerfile_test
+++ b/docker/Dockerfile_test
@@ -101,6 +101,8 @@ RUN  wget -P data/ https://s3-eu-west-1.amazonaws.com/mitie/total_word_feature_e
 
 RUN pip install -r alt_requirements/requirements_dev.txt
 
+RUN pip install -e .
+
 RUN  sed -i -e 's/backend      : tkagg/backend      : PDF/' /usr/local/lib/python2.7/site-packages/matplotlib/mpl-data/matplotlibrc
 
 VOLUME ["/app/projects", "/app/logs", "/app/data"]

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,7 +21,7 @@ If you want to use the bleeding edge version use github + setup.py:
     git clone https://github.com/RasaHQ/rasa_nlu.git
     cd rasa_nlu
     pip install -r requirements.txt
-    python setup.py install
+    pip install -e .
 
 rasa NLU allows you to use components to process your messages. E.g. there is a component for intent classification and
 there are several different components for entity recognition. The different components
@@ -38,7 +38,7 @@ installed and tell you which are missing, if any.
 
         pip install -r alt_requirements/requirements_full.txt
 
-    to install all requirements.
+    instead of ``requirements.txt`` to install all requirements.
 
 Setting up a backend
 ~~~~~~~~~~~~~~~~~~~~

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
--e .
 -r alt_requirements/requirements_bare.txt


### PR DESCRIPTION
**Proposed changes**:
- Removes `-e .` from all `requirements.txt` files (which messes with some tools, although recommended from parts of the python community - safer to separately do `pip install -r requirements.txt` and `pip install -e .`)

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
