### PR TITLE
default ensure_ascii=False for json dumps

### DIFF
--- a/alt_requirements/requirements_dev.txt
+++ b/alt_requirements/requirements_dev.txt
@@ -20,7 +20,7 @@ pytest-cov==2.5.1
 pytest-twisted==1.5
 pytest==3.0.7
 requests==2.18.1
-treq==17.3.1
+treq==17.8.0
 # other
 google-cloud-storage==1.0.0
 # docs

--- a/rasa_nlu/config.py
+++ b/rasa_nlu/config.py
@@ -8,6 +8,8 @@ import simplejson
 import os
 import six
 
+from rasa_nlu.utils import json_to_string
+
 # Describes where to search for the config file if no location is specified
 from typing import Text
 
@@ -131,7 +133,7 @@ class RasaNLUConfig(object):
         return dict(list(self.items()))
 
     def view(self):
-        return simplejson.dumps(self.__dict__, indent=4, ensure_ascii=False)
+        return json_to_string(self.__dict__, indent=4)
 
     def split_arg(self, config, arg_name):
         if arg_name in config and isinstance(config[arg_name], six.string_types):

--- a/rasa_nlu/config.py
+++ b/rasa_nlu/config.py
@@ -131,7 +131,7 @@ class RasaNLUConfig(object):
         return dict(list(self.items()))
 
     def view(self):
-        return simplejson.dumps(self.__dict__, indent=4)
+        return simplejson.dumps(self.__dict__, indent=4, ensure_ascii=False)
 
     def split_arg(self, config, arg_name):
         if arg_name in config and isinstance(config[arg_name], six.string_types):

--- a/rasa_nlu/convert.py
+++ b/rasa_nlu/convert.py
@@ -6,6 +6,7 @@ import argparse
 import io
 
 from rasa_nlu.converters import load_data
+from rasa_nlu.utils import write_to_file
 
 
 def create_argparser():
@@ -24,11 +25,8 @@ def create_argparser():
 
 def convert_training_data(data_file, out_file, output_format, language):
     td = load_data(data_file, language)
-    with io.open(out_file, "w", encoding='utf-8') as f:
-        if output_format == 'md':
-            f.write(td.as_markdown())
-        else:
-            f.write(td.as_json(indent=2))
+    output = td.as_markdown() if output_format == 'md' else td.as_json(indent=2)
+    write_to_file(out_file, output)
 
 
 if __name__ == "__main__":

--- a/rasa_nlu/extractors/duckling_extractor.py
+++ b/rasa_nlu/extractors/duckling_extractor.py
@@ -23,6 +23,7 @@ from rasa_nlu.model import Metadata
 from inspect import getmembers
 
 from rasa_nlu.training_data import Message
+from rasa_nlu.utils import write_json_to_file
 
 if typing.TYPE_CHECKING:
     from duckling import DucklingWrapper
@@ -152,8 +153,7 @@ class DucklingExtractor(EntityExtractor):
 
         file_name = self.name + ".json"
         full_name = os.path.join(model_dir, file_name)
-        with io.open(full_name, 'w') as f:
-            f.write(str(json.dumps({"dimensions": self.dimensions}, ensure_ascii=False)))
+        write_json_to_file(full_name, {"dimensions": self.dimensions})
         return {"ner_duckling_persisted": file_name}
 
     @classmethod

--- a/rasa_nlu/extractors/duckling_extractor.py
+++ b/rasa_nlu/extractors/duckling_extractor.py
@@ -153,7 +153,7 @@ class DucklingExtractor(EntityExtractor):
         file_name = self.name + ".json"
         full_name = os.path.join(model_dir, file_name)
         with io.open(full_name, 'w') as f:
-            f.write(str(json.dumps({"dimensions": self.dimensions})))
+            f.write(str(json.dumps({"dimensions": self.dimensions}, ensure_ascii=False)))
         return {"ner_duckling_persisted": file_name}
 
     @classmethod

--- a/rasa_nlu/extractors/duckling_http_extractor.py
+++ b/rasa_nlu/extractors/duckling_http_extractor.py
@@ -114,7 +114,7 @@ class DucklingHTTPExtractor(EntityExtractor):
 
         file_name = self.name + ".json"
         with io.open(os.path.join(model_dir, file_name), 'w') as f:
-            dumped = str(simplejson.dumps({"dimensions": self.dimensions}))
+            dumped = str(simplejson.dumps({"dimensions": self.dimensions}, ensure_ascii=False))
             f.write(dumped)
         return {self.name: file_name}
 

--- a/rasa_nlu/extractors/duckling_http_extractor.py
+++ b/rasa_nlu/extractors/duckling_http_extractor.py
@@ -20,6 +20,7 @@ from rasa_nlu.extractors import EntityExtractor
 from rasa_nlu.model import Metadata
 from rasa_nlu.training_data import Message
 from rasa_nlu.extractors.duckling_extractor import extract_value
+from rasa_nlu.utils import write_json_to_file
 
 logger = logging.getLogger(__name__)
 
@@ -113,9 +114,8 @@ class DucklingHTTPExtractor(EntityExtractor):
         # type: (Text) -> Dict[Text, Any]
 
         file_name = self.name + ".json"
-        with io.open(os.path.join(model_dir, file_name), 'w') as f:
-            dumped = str(simplejson.dumps({"dimensions": self.dimensions}, ensure_ascii=False))
-            f.write(dumped)
+        full_name = os.path.join(model_dir, file_name)
+        write_json_to_file(full_name, {"dimensions": self.dimensions})
         return {self.name: file_name}
 
     @classmethod

--- a/rasa_nlu/extractors/entity_synonyms.py
+++ b/rasa_nlu/extractors/entity_synonyms.py
@@ -57,7 +57,7 @@ class EntitySynonymMapper(EntityExtractor):
                                                 "entity_synonyms.json")
             with io.open(entity_synonyms_file, 'w') as f:
                 f.write(str(json.dumps(self.synonyms, indent=2,
-                                       separators=(',', ': '))))
+                                       separators=(',', ': '), ensure_ascii=False)))
             return {"entity_synonyms": "entity_synonyms.json"}
         else:
             return {"entity_synonyms": None}

--- a/rasa_nlu/extractors/entity_synonyms.py
+++ b/rasa_nlu/extractors/entity_synonyms.py
@@ -19,6 +19,7 @@ from rasa_nlu.extractors import EntityExtractor
 from rasa_nlu.model import Metadata
 from rasa_nlu.training_data import Message
 from rasa_nlu.training_data import TrainingData
+from rasa_nlu.utils import write_json_to_file
 
 
 class EntitySynonymMapper(EntityExtractor):
@@ -55,9 +56,8 @@ class EntitySynonymMapper(EntityExtractor):
         if self.synonyms:
             entity_synonyms_file = os.path.join(model_dir,
                                                 "entity_synonyms.json")
-            with io.open(entity_synonyms_file, 'w') as f:
-                f.write(str(json.dumps(self.synonyms, indent=2,
-                                       separators=(',', ': '), ensure_ascii=False)))
+            write_json_to_file(entity_synonyms_file, self.synonyms, separators=(',', ': '))
+
             return {"entity_synonyms": "entity_synonyms.json"}
         else:
             return {"entity_synonyms": None}

--- a/rasa_nlu/featurizers/regex_featurizer.py
+++ b/rasa_nlu/featurizers/regex_featurizer.py
@@ -22,6 +22,7 @@ from rasa_nlu.config import RasaNLUConfig
 from rasa_nlu.featurizers import Featurizer
 from rasa_nlu.training_data import Message
 from rasa_nlu.training_data import TrainingData
+from rasa_nlu.utils import write_json_to_file
 
 logger = logging.getLogger(__name__)
 
@@ -107,8 +108,7 @@ class RegexFeaturizer(Featurizer):
 
         if self.known_patterns:
             regex_file = os.path.join(model_dir, "regex_featurizer.json")
-            with io.open(regex_file, 'w') as f:
-                f.write(str(json.dumps(self.known_patterns, indent=4, ensure_ascii=False)))
+            write_json_to_file(regex_file, self.known_patterns, indent=4)
             return {"regex_featurizer": "regex_featurizer.json"}
         else:
             return {"regex_featurizer": None}

--- a/rasa_nlu/featurizers/regex_featurizer.py
+++ b/rasa_nlu/featurizers/regex_featurizer.py
@@ -108,7 +108,7 @@ class RegexFeaturizer(Featurizer):
         if self.known_patterns:
             regex_file = os.path.join(model_dir, "regex_featurizer.json")
             with io.open(regex_file, 'w') as f:
-                f.write(str(json.dumps(self.known_patterns, indent=4)))
+                f.write(str(json.dumps(self.known_patterns, indent=4, ensure_ascii=False)))
             return {"regex_featurizer": "regex_featurizer.json"}
         else:
             return {"regex_featurizer": None}

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -96,7 +96,7 @@ class Metadata(object):
         })
 
         with io.open(os.path.join(model_dir, 'metadata.json'), 'w') as f:
-            f.write(str(json.dumps(metadata, indent=4)))
+            f.write(str(json.dumps(metadata, indent=4, ensure_ascii=False)))
 
 
 class Trainer(object):

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -25,7 +25,7 @@ from rasa_nlu.components import ComponentBuilder
 from rasa_nlu.config import RasaNLUConfig
 from rasa_nlu.persistor import Persistor
 from rasa_nlu.training_data import TrainingData, Message
-from rasa_nlu.utils import create_dir
+from rasa_nlu.utils import create_dir, write_json_to_file
 
 logger = logging.getLogger(__name__)
 
@@ -95,8 +95,8 @@ class Metadata(object):
             "rasa_nlu_version": rasa_nlu.__version__,
         })
 
-        with io.open(os.path.join(model_dir, 'metadata.json'), 'w') as f:
-            f.write(str(json.dumps(metadata, indent=4, ensure_ascii=False)))
+        filename = os.path.join(model_dir, 'metadata.json')
+        write_json_to_file(filename, metadata, indent=4)
 
 
 class Trainer(object):

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -147,22 +147,22 @@ class RasaNLU(object):
         if 'q' not in request_params:
             request.setResponseCode(404)
             dumped = simplejson.dumps({
-                "error": "Invalid parse parameter specified"})
+                "error": "Invalid parse parameter specified"}, ensure_ascii=False)
             returnValue(dumped)
         else:
             data = self.data_router.extract(request_params)
             try:
                 request.setResponseCode(200)
                 response = yield (self.data_router.parse(data) if self._testing
-                                  else threads.deferToThread(self.data_router.parse, data))
-                returnValue(simplejson.dumps(response))
+                                    else threads.deferToThread(self.data_router.parse, data))
+                returnValue(simplejson.dumps(response, ensure_ascii=False))
             except InvalidProjectError as e:
                 request.setResponseCode(404)
-                returnValue(simplejson.dumps({"error": "{}".format(e)}))
+                returnValue(simplejson.dumps({"error": "{}".format(e)}, ensure_ascii=False))
             except Exception as e:
                 request.setResponseCode(500)
                 logger.exception(e)
-                returnValue(simplejson.dumps({"error": "{}".format(e)}))
+                returnValue(simplejson.dumps({"error": "{}".format(e)}, ensure_ascii=False))
 
     @app.route("/version", methods=['GET', 'OPTIONS'])
     @requires_auth
@@ -171,7 +171,7 @@ class RasaNLU(object):
         """Returns the Rasa server's version"""
 
         request.setHeader('Content-Type', 'application/json')
-        return simplejson.dumps({'version': __version__})
+        return simplejson.dumps({'version': __version__}, ensure_ascii=False)
 
     @app.route("/config", methods=['GET', 'OPTIONS'])
     @requires_auth
@@ -180,14 +180,14 @@ class RasaNLU(object):
         """Returns the in-memory configuration of the Rasa server"""
 
         request.setHeader('Content-Type', 'application/json')
-        return simplejson.dumps(self.config.as_dict())
+        return simplejson.dumps(self.config.as_dict(), ensure_ascii=False)
 
     @app.route("/status", methods=['GET', 'OPTIONS'])
     @requires_auth
     @check_cors
     def status(self, request):
         request.setHeader('Content-Type', 'application/json')
-        return simplejson.dumps(self.data_router.get_status())
+        return simplejson.dumps(self.data_router.get_status(), ensure_ascii=False)
 
     @app.route("/train", methods=['POST', 'OPTIONS'])
     @requires_auth
@@ -204,19 +204,19 @@ class RasaNLU(object):
             response = yield self.data_router.start_train_process(
                     data_string, kwargs)
             returnValue(simplejson.dumps(
-                    {'info': 'new model trained: {}'.format(response)}))
+                    {'info': 'new model trained: {}'.format(response)}, ensure_ascii=False))
         except AlreadyTrainingError as e:
             request.setResponseCode(403)
             returnValue(simplejson.dumps(
-                    {"error": "{}".format(e)}))
+                    {"error": "{}".format(e)}, ensure_ascii=False))
         except InvalidProjectError as e:
             request.setResponseCode(404)
             returnValue(simplejson.dumps(
-                    {"error": "{}".format(e)}))
+                    {"error": "{}".format(e)}, ensure_ascii=False))
         except TrainingException as e:
             request.setResponseCode(500)
             returnValue(simplejson.dumps(
-                    {"error": "{}".format(e)}))
+                    {"error": "{}".format(e)}, ensure_ascii=False))
 
 
 if __name__ == '__main__':

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -21,6 +21,7 @@ from rasa_nlu.data_router import DataRouter, InvalidProjectError, \
     AlreadyTrainingError
 from rasa_nlu.train import TrainingException
 from rasa_nlu.version import __version__
+from rasa_nlu.utils import json_to_string
 
 logger = logging.getLogger(__name__)
 
@@ -146,8 +147,7 @@ class RasaNLU(object):
 
         if 'q' not in request_params:
             request.setResponseCode(404)
-            dumped = simplejson.dumps({
-                "error": "Invalid parse parameter specified"}, ensure_ascii=False)
+            dumped = json_to_string({"error": "Invalid parse parameter specified"})
             returnValue(dumped)
         else:
             data = self.data_router.extract(request_params)
@@ -155,14 +155,14 @@ class RasaNLU(object):
                 request.setResponseCode(200)
                 response = yield (self.data_router.parse(data) if self._testing
                                   else threads.deferToThread(self.data_router.parse, data))
-                returnValue(simplejson.dumps(response, ensure_ascii=False))
+                returnValue(json_to_string(response))
             except InvalidProjectError as e:
                 request.setResponseCode(404)
-                returnValue(simplejson.dumps({"error": "{}".format(e)}, ensure_ascii=False))
+                returnValue(json_to_string({"error": "{}".format(e)}))
             except Exception as e:
                 request.setResponseCode(500)
                 logger.exception(e)
-                returnValue(simplejson.dumps({"error": "{}".format(e)}, ensure_ascii=False))
+                returnValue(json_to_string({"error": "{}".format(e)}))
 
     @app.route("/version", methods=['GET', 'OPTIONS'])
     @requires_auth
@@ -171,7 +171,7 @@ class RasaNLU(object):
         """Returns the Rasa server's version"""
 
         request.setHeader('Content-Type', 'application/json')
-        return simplejson.dumps({'version': __version__}, ensure_ascii=False)
+        return json_to_string({'version': __version__})
 
     @app.route("/config", methods=['GET', 'OPTIONS'])
     @requires_auth
@@ -180,14 +180,15 @@ class RasaNLU(object):
         """Returns the in-memory configuration of the Rasa server"""
 
         request.setHeader('Content-Type', 'application/json')
-        return simplejson.dumps(self.config.as_dict(), ensure_ascii=False)
+        return json_to_string(self.config.as_dict())
 
     @app.route("/status", methods=['GET', 'OPTIONS'])
     @requires_auth
     @check_cors
     def status(self, request):
         request.setHeader('Content-Type', 'application/json')
-        return simplejson.dumps(self.data_router.get_status(), ensure_ascii=False)
+        self.string = json_to_string(self.data_router.get_status())
+        return self.string
 
     @app.route("/train", methods=['POST', 'OPTIONS'])
     @requires_auth
@@ -203,20 +204,16 @@ class RasaNLU(object):
             request.setResponseCode(200)
             response = yield self.data_router.start_train_process(
                     data_string, kwargs)
-            returnValue(simplejson.dumps(
-                    {'info': 'new model trained: {}'.format(response)}, ensure_ascii=False))
+            returnValue(json_to_string({'info': 'new model trained: {}'.format(response)}))
         except AlreadyTrainingError as e:
             request.setResponseCode(403)
-            returnValue(simplejson.dumps(
-                    {"error": "{}".format(e)}, ensure_ascii=False))
+            returnValue(json_to_string({"error": "{}".format(e)}))
         except InvalidProjectError as e:
             request.setResponseCode(404)
-            returnValue(simplejson.dumps(
-                    {"error": "{}".format(e)}, ensure_ascii=False))
+            returnValue(json_to_string({"error": "{}".format(e)}))
         except TrainingException as e:
             request.setResponseCode(500)
-            returnValue(simplejson.dumps(
-                    {"error": "{}".format(e)}, ensure_ascii=False))
+            returnValue(json_to_string({"error": "{}".format(e)}))
 
 
 if __name__ == '__main__':

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -154,7 +154,7 @@ class RasaNLU(object):
             try:
                 request.setResponseCode(200)
                 response = yield (self.data_router.parse(data) if self._testing
-                                    else threads.deferToThread(self.data_router.parse, data))
+                                  else threads.deferToThread(self.data_router.parse, data))
                 returnValue(simplejson.dumps(response, ensure_ascii=False))
             except InvalidProjectError as e:
                 request.setResponseCode(404)

--- a/rasa_nlu/training_data.py
+++ b/rasa_nlu/training_data.py
@@ -22,8 +22,9 @@ from typing import List
 from typing import Optional
 from typing import Text
 
-from rasa_nlu.utils import lazyproperty, ordered
+from rasa_nlu.utils import lazyproperty, ordered, write_to_file
 from rasa_nlu.utils import list_to_str
+from rasa_nlu.utils import json_to_string
 
 logger = logging.getLogger(__name__)
 
@@ -142,13 +143,13 @@ class TrainingData(object):
         formatted_examples = [example.as_dict()
                               for example in self.training_examples]
 
-        return str(json.dumps({
+        return str(json_to_string({
             "rasa_nlu_data": {
                 "common_examples": formatted_examples,
                 "regex_features": self.regex_features,
                 "entity_synonyms": formatted_synonyms
             }
-        }, ensure_ascii=False, **kwargs))
+        }, **kwargs))
 
     def as_markdown(self, **kwargs):
         # type: (**Any) -> str
@@ -164,8 +165,7 @@ class TrainingData(object):
         information to load it again."""
 
         data_file = os.path.join(dir_name, "training_data.json")
-        with io.open(data_file, 'w') as f:
-            f.write(self.as_json(indent=2))
+        write_to_file(data_file, self.as_json(indent=2))
 
         return {
             "training_data": "training_data.json"

--- a/rasa_nlu/training_data.py
+++ b/rasa_nlu/training_data.py
@@ -148,7 +148,7 @@ class TrainingData(object):
                 "regex_features": self.regex_features,
                 "entity_synonyms": formatted_synonyms
             }
-        }, **kwargs))
+        }, ensure_ascii=False, **kwargs))
 
     def as_markdown(self, **kwargs):
         # type: (**Any) -> str

--- a/rasa_nlu/utils/__init__.py
+++ b/rasa_nlu/utils/__init__.py
@@ -4,10 +4,13 @@ from __future__ import division
 from __future__ import absolute_import
 import os
 
+from builtins import str
 import errno
 from typing import List
 from typing import Optional
 from typing import Text
+import json
+import io
 
 
 def relative_normpath(f, path):
@@ -123,3 +126,24 @@ def class_from_module_path(module_path):
         return getattr(m, class_name)
     else:
         return globals()[module_path]
+
+
+def json_to_string(obj, **kwargs):
+    indent = kwargs.pop("indent", 2)
+    ensure_ascii = kwargs.pop("ensure_ascii", False)
+    return json.dumps(obj, indent=indent, ensure_ascii=ensure_ascii, **kwargs)
+
+
+def write_json_to_file(filename, obj, **kwargs):
+    # type: (Text, Any) -> None
+    """Write an object as a json string to a file."""
+
+    write_to_file(filename, json_to_string(obj, **kwargs))
+
+
+def write_to_file(filename, text):
+    # type: (Text, Text) -> None
+    """Write a text to a file."""
+
+    with io.open(filename, 'w', encoding="utf-8") as f:
+        f.write(str(text))

--- a/tests/base/test_multitenancy.py
+++ b/tests/base/test_multitenancy.py
@@ -109,7 +109,7 @@ def test_get_parse_invalid_model(app, response_test):
 ])
 @pytest.inlineCallbacks
 def test_post_parse(app, response_test):
-    response = yield app.post(response_test.endpoint, data=json.dumps(response_test.payload),
+    response = yield app.post(response_test.endpoint, data=json.dumps(response_test.payload, ensure_ascii=False),
                               content_type='application/json')
     rjs = yield response.json()
     assert response.code == 200
@@ -123,7 +123,8 @@ def test_post_parse_specific_model(app):
     model = sjs["available_projects"]["test_project_mitie"]["available_models"][0]
     query = ResponseTest("http://dummy_uri/parse", {"entities": [], "intent": "affirm", "text": "food"},
                          payload={"q": "food", "project": "test_project_mitie", "model": model})
-    response = yield app.post(query.endpoint, data=json.dumps(query.payload), content_type='application/json')
+    response = yield app.post(query.endpoint, data=json.dumps(query.payload, ensure_ascii=False),
+                              content_type='application/json')
     assert response.code == 200
 
 
@@ -141,7 +142,7 @@ def test_post_parse_specific_model(app):
 ])
 @pytest.inlineCallbacks
 def test_post_parse_invalid_model(app, response_test):
-    response = yield app.post(response_test.endpoint, data=json.dumps(response_test.payload),
+    response = yield app.post(response_test.endpoint, data=json.dumps(response_test.payload, ensure_ascii=False),
                               content_type='application/json')
     rjs = yield response.json()
     assert response.code == 404

--- a/tests/base/test_multitenancy.py
+++ b/tests/base/test_multitenancy.py
@@ -51,16 +51,16 @@ def app(component_builder):
 
 @pytest.mark.parametrize("response_test", [
     ResponseTest(
-        "http://dummy_uri/parse?q=food&project=test_project_mitie",
-        {"entities": [], "intent": "affirm", "text": "food"}
+            "http://dummy_uri/parse?q=food&project=test_project_mitie",
+            {"entities": [], "intent": "affirm", "text": "food"}
     ),
     ResponseTest(
-        "http://dummy_uri/parse?q=food&project=test_project_mitie_sklearn",
-        {"entities": [], "intent": "restaurant_search", "text": "food"}
+            "http://dummy_uri/parse?q=food&project=test_project_mitie_sklearn",
+            {"entities": [], "intent": "restaurant_search", "text": "food"}
     ),
     ResponseTest(
-        "http://dummy_uri/parse?q=food&project=test_project_spacy_sklearn",
-        {"entities": [], "intent": "restaurant_search", "text": "food"}
+            "http://dummy_uri/parse?q=food&project=test_project_spacy_sklearn",
+            {"entities": [], "intent": "restaurant_search", "text": "food"}
     ),
 ])
 @pytest.inlineCallbacks
@@ -74,12 +74,12 @@ def test_get_parse(app, response_test):
 
 @pytest.mark.parametrize("response_test", [
     ResponseTest(
-        "http://dummy_uri/parse?q=food",
-        {"error": "No project found with name 'default'."}
+            "http://dummy_uri/parse?q=food",
+            {"error": "No project found with name 'default'."}
     ),
     ResponseTest(
-        "http://dummy_uri/parse?q=food&project=umpalumpa",
-        {"error": "No project found with name 'umpalumpa'."}
+            "http://dummy_uri/parse?q=food&project=umpalumpa",
+            {"error": "No project found with name 'umpalumpa'."}
     )
 ])
 @pytest.inlineCallbacks
@@ -92,25 +92,24 @@ def test_get_parse_invalid_model(app, response_test):
 
 @pytest.mark.parametrize("response_test", [
     ResponseTest(
-        "http://dummy_uri/parse",
-        {"entities": [], "intent": "affirm", "text": "food"},
-        payload={"q": "food", "project": "test_project_mitie"}
+            "http://dummy_uri/parse",
+            {"entities": [], "intent": "affirm", "text": "food"},
+            payload={"q": "food", "project": "test_project_mitie"}
     ),
     ResponseTest(
-        "http://dummy_uri/parse",
-        {"entities": [], "intent": "restaurant_search", "text": "food"},
-        payload={"q": "food", "project": "test_project_mitie_sklearn"}
+            "http://dummy_uri/parse",
+            {"entities": [], "intent": "restaurant_search", "text": "food"},
+            payload={"q": "food", "project": "test_project_mitie_sklearn"}
     ),
     ResponseTest(
-        "http://dummy_uri/parse",
-        {"entities": [], "intent": "restaurant_search", "text": "food"},
-        payload={"q": "food", "project": "test_project_spacy_sklearn"}
+            "http://dummy_uri/parse",
+            {"entities": [], "intent": "restaurant_search", "text": "food"},
+            payload={"q": "food", "project": "test_project_spacy_sklearn"}
     ),
 ])
 @pytest.inlineCallbacks
 def test_post_parse(app, response_test):
-    response = yield app.post(response_test.endpoint, data=json.dumps(response_test.payload, ensure_ascii=False),
-                              content_type='application/json')
+    response = yield app.post(response_test.endpoint, json=response_test.payload)
     rjs = yield response.json()
     assert response.code == 200
     assert all(prop in rjs for prop in ['entities', 'intent', 'text'])
@@ -123,27 +122,25 @@ def test_post_parse_specific_model(app):
     model = sjs["available_projects"]["test_project_mitie"]["available_models"][0]
     query = ResponseTest("http://dummy_uri/parse", {"entities": [], "intent": "affirm", "text": "food"},
                          payload={"q": "food", "project": "test_project_mitie", "model": model})
-    response = yield app.post(query.endpoint, data=json.dumps(query.payload, ensure_ascii=False),
-                              content_type='application/json')
+    response = yield app.post(query.endpoint, json=query.payload)
     assert response.code == 200
 
 
 @pytest.mark.parametrize("response_test", [
     ResponseTest(
-        "http://dummy_uri/parse",
-        {"error": "No project found with name 'default'."},
-        payload={"q": "food"}
+            "http://dummy_uri/parse",
+            {"error": "No project found with name 'default'."},
+            payload={"q": "food"}
     ),
     ResponseTest(
-        "http://dummy_uri/parse",
-        {"error": "No project found with name 'umpalumpa'."},
-        payload={"q": "food", "project": "umpalumpa"}
+            "http://dummy_uri/parse",
+            {"error": "No project found with name 'umpalumpa'."},
+            payload={"q": "food", "project": "umpalumpa"}
     ),
 ])
 @pytest.inlineCallbacks
 def test_post_parse_invalid_model(app, response_test):
-    response = yield app.post(response_test.endpoint, data=json.dumps(response_test.payload, ensure_ascii=False),
-                              content_type='application/json')
+    response = yield app.post(response_test.endpoint, json=response_test.payload)
     rjs = yield response.json()
     assert response.code == 404
     assert rjs.get("error").startswith(response_test.expected_response["error"])

--- a/tests/base/test_server.py
+++ b/tests/base/test_server.py
@@ -126,7 +126,7 @@ def test_get_parse(app, response_test):
 ])
 @pytest.inlineCallbacks
 def test_post_parse(app, response_test):
-    response = yield app.post(response_test.endpoint, data=json.dumps(response_test.payload),
+    response = yield app.post(response_test.endpoint, data=json.dumps(response_test.payload, ensure_ascii=False),
                               content_type='application/json')
     rjs = yield response.json()
     assert response.code == 200
@@ -137,7 +137,7 @@ def test_post_parse(app, response_test):
 @utilities.slowtest
 @pytest.inlineCallbacks
 def test_post_train(app, rasa_default_train_data):
-    response = app.post("http://dummy_uri/train", data=json.dumps(rasa_default_train_data),
+    response = app.post("http://dummy_uri/train", data=json.dumps(rasa_default_train_data, ensure_ascii=False),
                         content_type='application/json')
     time.sleep(3)
     app.flush()
@@ -151,7 +151,7 @@ def test_post_train(app, rasa_default_train_data):
 @pytest.inlineCallbacks
 def test_post_train_internal_error(app, rasa_default_train_data):
     response = app.post("http://dummy_uri/train?project=test",
-                        data=json.dumps({"data": "dummy_data_for_triggering_an_error"}),
+                        data=json.dumps({"data": "dummy_data_for_triggering_an_error"}, ensure_ascii=False),
                         content_type='application/json')
     time.sleep(3)
     app.flush()
@@ -168,7 +168,7 @@ def test_model_hot_reloading(app, rasa_default_train_data):
     assert response.code == 404, "Project should not exist yet"
     train_u = "http://dummy_uri/train?project=my_keyword_model&pipeline=keyword"
     response = app.post(train_u,
-                        data=json.dumps(rasa_default_train_data),
+                        data=json.dumps(rasa_default_train_data, ensure_ascii=False),
                         content_type='application/json')
     time.sleep(3)
     app.flush()

--- a/tests/base/test_server.py
+++ b/tests/base/test_server.py
@@ -82,20 +82,20 @@ def test_version(app):
 
 @pytest.mark.parametrize("response_test", [
     ResponseTest(
-        "http://dummy_uri/parse?q=hello",
-        [{"entities": {}, "confidence": 1.0, "intent": "greet", "_text": "hello"}]
+            "http://dummy_uri/parse?q=hello",
+            [{"entities": {}, "confidence": 1.0, "intent": "greet", "_text": "hello"}]
     ),
     ResponseTest(
-        "http://dummy_uri/parse?query=hello",
-        [{"entities": {}, "confidence": 1.0, "intent": "greet", "_text": "hello"}]
+            "http://dummy_uri/parse?query=hello",
+            [{"entities": {}, "confidence": 1.0, "intent": "greet", "_text": "hello"}]
     ),
     ResponseTest(
-        "http://dummy_uri/parse?q=hello ńöñàśçií",
-        [{"entities": {}, "confidence": 1.0, "intent": "greet", "_text": "hello ńöñàśçií"}]
+            "http://dummy_uri/parse?q=hello ńöñàśçií",
+            [{"entities": {}, "confidence": 1.0, "intent": "greet", "_text": "hello ńöñàśçií"}]
     ),
     ResponseTest(
-        "http://dummy_uri/parse?q=",
-        [{"entities": {}, "confidence": 0.0, "intent": None, "_text": ""}]
+            "http://dummy_uri/parse?q=",
+            [{"entities": {}, "confidence": 0.0, "intent": None, "_text": ""}]
     ),
 ])
 @pytest.inlineCallbacks
@@ -109,25 +109,24 @@ def test_get_parse(app, response_test):
 
 @pytest.mark.parametrize("response_test", [
     ResponseTest(
-        "http://dummy_uri/parse",
-        [{"entities": {}, "confidence": 1.0, "intent": "greet", "_text": "hello"}],
-        payload={"q": "hello"}
+            "http://dummy_uri/parse",
+            [{"entities": {}, "confidence": 1.0, "intent": "greet", "_text": "hello"}],
+            payload={"q": "hello"}
     ),
     ResponseTest(
-        "http://dummy_uri/parse",
-        [{"entities": {}, "confidence": 1.0, "intent": "greet", "_text": "hello"}],
-        payload={"query": "hello"}
+            "http://dummy_uri/parse",
+            [{"entities": {}, "confidence": 1.0, "intent": "greet", "_text": "hello"}],
+            payload={"query": "hello"}
     ),
     ResponseTest(
-        "http://dummy_uri/parse",
-        [{"entities": {}, "confidence": 1.0, "intent": "greet", "_text": "hello ńöñàśçií"}],
-        payload={"q": "hello ńöñàśçií"}
+            "http://dummy_uri/parse",
+            [{"entities": {}, "confidence": 1.0, "intent": "greet", "_text": "hello ńöñàśçií"}],
+            payload={"q": "hello ńöñàśçií"}
     ),
 ])
 @pytest.inlineCallbacks
 def test_post_parse(app, response_test):
-    response = yield app.post(response_test.endpoint, data=json.dumps(response_test.payload, ensure_ascii=False),
-                              content_type='application/json')
+    response = yield app.post(response_test.endpoint, json=response_test.payload)
     rjs = yield response.json()
     assert response.code == 200
     assert len(rjs) == 1
@@ -137,8 +136,7 @@ def test_post_parse(app, response_test):
 @utilities.slowtest
 @pytest.inlineCallbacks
 def test_post_train(app, rasa_default_train_data):
-    response = app.post("http://dummy_uri/train", data=json.dumps(rasa_default_train_data, ensure_ascii=False),
-                        content_type='application/json')
+    response = app.post("http://dummy_uri/train", json=rasa_default_train_data)
     time.sleep(3)
     app.flush()
     response = yield response
@@ -151,8 +149,7 @@ def test_post_train(app, rasa_default_train_data):
 @pytest.inlineCallbacks
 def test_post_train_internal_error(app, rasa_default_train_data):
     response = app.post("http://dummy_uri/train?project=test",
-                        data=json.dumps({"data": "dummy_data_for_triggering_an_error"}, ensure_ascii=False),
-                        content_type='application/json')
+                        json={"data": "dummy_data_for_triggering_an_error"})
     time.sleep(3)
     app.flush()
     response = yield response
@@ -167,9 +164,7 @@ def test_model_hot_reloading(app, rasa_default_train_data):
     response = yield app.get(query)
     assert response.code == 404, "Project should not exist yet"
     train_u = "http://dummy_uri/train?project=my_keyword_model&pipeline=keyword"
-    response = app.post(train_u,
-                        data=json.dumps(rasa_default_train_data, ensure_ascii=False),
-                        content_type='application/json')
+    response = app.post(train_u, json=rasa_default_train_data)
     time.sleep(3)
     app.flush()
     response = yield response

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -15,6 +15,7 @@ from rasa_nlu.project import Project
 from rasa_nlu.config import RasaNLUConfig
 from rasa_nlu.model import Interpreter, Metadata
 from rasa_nlu.train import do_train
+from rasa_nlu.utils import json_to_string
 
 slowtest = pytest.mark.slowtest
 
@@ -31,7 +32,7 @@ def base_test_conf(pipeline_template):
 
 def write_file_config(file_config):
     with tempfile.NamedTemporaryFile("w+", suffix="_tmp_config_file.json", delete=False) as f:
-        f.write(json.dumps(file_config, ensure_ascii=False))
+        f.write(json_to_string(file_config))
         f.flush()
         return f
 

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -31,7 +31,7 @@ def base_test_conf(pipeline_template):
 
 def write_file_config(file_config):
     with tempfile.NamedTemporaryFile("w+", suffix="_tmp_config_file.json", delete=False) as f:
-        f.write(json.dumps(file_config))
+        f.write(json.dumps(file_config, ensure_ascii=False))
         f.flush()
         return f
 


### PR DESCRIPTION
**Proposed changes**:
- Fix #683 
- Use `ensure_ascii=False` as default for `json.dumps` so that non-ascii characters are not escaped. Any opinion on this approach vs. having a wrapper for `json.dumps` that we use across the code base?

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] updated the changelog
