### PR TITLE
Update pipeline.rst

### DIFF
--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -31,7 +31,7 @@ For example, the ``entities`` attribute is created by the ``ner_crf`` component.
 Pre-configured Pipelines
 ------------------------
 To ease the burden of coming up with your own processing pipelines, we provide a couple of ready to use templates
-which can be used by settings the ``pipeline`` configuration value to the name of the template you want to use.
+which can be used by setting the ``pipeline`` configuration value to the name of the template you want to use.
 Here is a list of the existing templates:
 
 +---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -273,8 +273,7 @@ ner_synonyms
                         "start": 11,
                         "end": 24,
                         "entity": "city",
-                        "extractor" "ner_mitie",
-                        "processor": ["ner_synonyms"]}]
+                       }]
         },
         {
           "text": "I got a new flat in NYC.",
@@ -283,8 +282,7 @@ ner_synonyms
                         "start": 20,
                         "end": 23,
                         "entity": "city",
-                        "extractor" "ner_mitie",
-                        "processor": ["ner_synonyms"]}]
+                       }]
         }]
 
     this component will allow you to map the entities ``New York City`` and ``NYC`` to ``nyc``. The entitiy


### PR DESCRIPTION
**Proposed changes**:
- In the pipeline documentation for the ner_synonyms processor, the processor output was shown as part of the training data, removed it. 
- Fixed a minor typo.