### PR TITLE
Fixes entity parsing in markdown

### DIFF
--- a/data/examples/rasa/demo-rasa.json
+++ b/data/examples/rasa/demo-rasa.json
@@ -152,7 +152,7 @@
         ]
       },
       {
-        "text": "show me chines restaurants",
+        "text": "show me chines restaurants in the north",
         "intent": "restaurant_search",
         "entities": [
           {
@@ -160,6 +160,12 @@
             "end": 14,
             "value": "chinese",
             "entity": "cuisine"
+          },
+          {
+            "start": 34,
+            "end": 39,
+            "value": "north",
+            "entity": "location"
           }
         ]
       },

--- a/data/examples/rasa/demo-rasa.md
+++ b/data/examples/rasa/demo-rasa.md
@@ -37,7 +37,7 @@
 - I am searching for a dinner spot
 - i'm looking for a place in the [north](location) of town
 - show me [chinese](cuisine) restaurants
-- show me [chines](cuisine:chinese) restaurants
+- show me [chines](cuisine:chinese) restaurants in the [north](location)
 - show me a [mexican](cuisine) place in the [centre](location)
 - i am looking for an [indian](cuisine) spot called olaolaolaolaolaola
 - search for restaurants

--- a/rasa_nlu/utils/md_to_json.py
+++ b/rasa_nlu/utils/md_to_json.py
@@ -7,11 +7,9 @@ import re
 import io
 from rasa_nlu.training_data import Message
 
-ent_regex = re.compile(r'\[(?P<value>[^\]]+)]'
-                       r'\((?P<entity>[^:)]+)\)')  # [restaurant](what)
-ent_regex_with_value = re.compile(r'\[(?P<synonym>[^\]]+)'
-                                  r'\]\((?P<entity>\w*?):'
-                                  r'(?P<value>[^)]+)\)')  # [open](open:1)
+ent_regex = re.compile(r'\[(?P<synonym>[^\]]+)'
+                       r'\]\((?P<entity>\w*?)'
+                       r'(?:\:(?P<value>[^)]+))?\)')  # [open](open:1)
 intent_regex = re.compile(r'##\s*intent:(.+)')
 synonym_regex = re.compile(r'##\s*synonym:(.+)')
 example_regex = re.compile(r'\s*[-\*]\s*(.+)')
@@ -19,6 +17,7 @@ comment_regex = re.compile(r'<!--[\s\S]*?--!*>', re.MULTILINE)
 
 INTENT_PARSING_STATE = "intent"
 SYNONYM_PARSING_STATE = "synonym"
+
 
 def strip_comments(comment_regex, text):
     """ Removes comments defined by `comment_regex` from `text`. """
@@ -79,24 +78,27 @@ class MarkdownToJson(object):
     def _parse_intent_example(self, example_in_md):
         entities = []
         utter = example_in_md
-        for regex in [ent_regex, ent_regex_with_value]:
-            utter = re.sub(regex, r"\1", utter)  # [text](entity) -> text
-            ent_matches = re.finditer(regex, example_in_md)
-            for matchNum, match in enumerate(ent_matches):
-                if 'synonym' in match.groupdict():
-                    entity_value_in_utter = match.groupdict()['synonym']
-                else:
-                    entity_value_in_utter = match.groupdict()['value']
+        match = re.search(ent_regex, utter)
+        while match is not None:
+            entity_synonym = match.groupdict()['synonym']
+            entity_entity = match.groupdict()['entity']
+            entity_value = match.groupdict()['value']
 
-                start_index = utter.index(entity_value_in_utter)
-                end_index = start_index + len(entity_value_in_utter)
+            if match.groupdict()['value'] is None:
+                entity_value = entity_synonym
 
-                entities.append({
-                    'entity': match.groupdict()['entity'],
-                    'value': match.groupdict()['value'],
-                    'start': start_index,
-                    'end': end_index
-                })
+            start_index = match.start()
+            end_index = start_index + len(entity_synonym)
+
+            entities.append({
+                'entity': entity_entity,
+                'value': entity_value,
+                'start': start_index,
+                'end': end_index
+            })
+
+            utter = utter[:match.start()] + entity_synonym + utter[match.end():]
+            match = re.search(ent_regex, utter)
 
         message = Message(utter, {'intent': self.current_intent})
         if len(entities) > 0:

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -77,6 +77,12 @@ def test_markdown_data():
                                   u'vegg': u'vegetarian', u'veggie': u'vegetarian'}
 
 
+def test_compare_markdown_to_json():
+    td_md = load_data('data/examples/rasa/demo-rasa.md')
+    td_json = load_data('data/examples/rasa/demo-rasa.json')
+    assert td_md.sorted_entity_examples() == td_json.sorted_entity_examples()
+
+
 def test_markdown_data_asterisks_format():
     td = load_data('data/test/demo-rasa-small.md')
     assert len(td.sorted_entity_examples()) >= len([e for e in td.entity_examples if e.get("entities")])


### PR DESCRIPTION
**Proposed changes**:
- Fixes entity parsing in Markdown converter  
Previously samples such as `show me [chines](cuisine:chinese) restaurants in the [north](location)` would get wrong start/end offsets due to the use of two regexes in the code

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
