### PR TITLE
fixed @sys.ignore entities all around when converting from Dialogflow

### DIFF
--- a/rasa_nlu/converters.py
+++ b/rasa_nlu/converters.py
@@ -64,14 +64,15 @@ def load_dialogflow_data(files, language):
                     end = start + len(e["text"])
                     val = text[start:end]
                     entity_type = e["alias"] if "alias" in e else e["meta"]
-                    entities.append(
-                        {
-                            "entity": entity_type,
-                            "value": val,
-                            "start": start,
-                            "end": end
-                        }
-                    )
+                    if entity_type != u'@sys.ignore':
+                        entities.append(
+                            {
+                                "entity": entity_type,
+                                "value": val,
+                                "start": start,
+                                "end": end
+                            }
+                        )
                 data = {}
                 if intent:
                     data["intent"] = intent


### PR DESCRIPTION
**Proposed changes**:
When converting from DialogFlow you get this `@sys.ignore` all over the place. The PR is a simple fix for this

```
## intent:smalltalk.user.wants_to_talk
- [je veux](@sys.ignore) parler [avec toi](@sys.ignore)
- [et](@sys.ignore) [si](@sys.ignore) [on](@sys.ignore) discutait
- [j](@sys.ignore)'aimerais bavarder

```

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
