### PR TITLE
setup.py was missing license field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
     description="Rasa NLU a natural language parser for bots",
     author='Alan Nichol',
     author_email='alan@rasa.ai',
+    license='Apache-2.0',
     url="https://rasa.com",
     keywords=["nlp", "machine-learning", "machine-learning-library", "bot",
               "bots",


### PR DESCRIPTION
**Proposed changes**:

While it has no effect on the actual license or the usability of this library, it hinders the use of tools like `pip-licenses`.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
