### PR TITLE
New feature: component can specify languages it handles

### DIFF
--- a/rasa_nlu/components.py
+++ b/rasa_nlu/components.py
@@ -14,6 +14,7 @@ from typing import Optional
 from typing import Set
 from typing import Text
 from typing import Tuple
+from typing import Hashable
 
 from rasa_nlu.config import RasaNLUConfig
 from rasa_nlu.training_data import Message
@@ -141,6 +142,13 @@ class Component(object):
     # previous component in the pipeline needs to have "tokens"
     # within the above described `provides` property.
     requires = []
+
+    # Defines what language(s) this component can handle.
+    # This attribute is designed for instance method: `can_handle_language`.
+    # Default value is None which means it can handle all languages.
+    # This is important feature that can backward-compatible with
+    # old style components.
+    _language_list = None
 
     def __init__(self):
         self.partial_processing_pipeline = None
@@ -276,6 +284,18 @@ class Component(object):
             logger.info("Failed to run partial processing due "
                         "to missing pipeline.")
         return message
+
+    def can_handle_language(self, language):
+        # type: (Hashable) -> bool
+        """Check if component support specific language.
+
+        this method can overwrite when needed.
+        (e.g. dynamic determine which language is supported.)"""
+
+        if self._language_list is None:  # None means support all languages
+            return True
+
+        return language in self._language_list
 
 
 class ComponentBuilder(object):

--- a/rasa_nlu/components.py
+++ b/rasa_nlu/components.py
@@ -202,7 +202,7 @@ class Component(object):
         language = config.get('language', None)
         if not cls.can_handle_language(language):
             # check failed
-            raise Exception("component {} not support language {}".format(cls.name, language))
+            raise Exception("component {} does not support language {}".format(cls.name, language))
 
         return cls()
 

--- a/rasa_nlu/components.py
+++ b/rasa_nlu/components.py
@@ -104,8 +104,24 @@ class MissingArgumentError(ValueError):
 
 
 class NoLanguageSupportingError(Exception):
-    """Raised when a component is created but the language is not supported."""
-    pass
+    """Raised when a component is created but the language is not supported.
+
+    Attributes:
+        component -- component name
+        language -- language that component not support
+    """
+
+    def __init__(self, component, language):
+        # type: (Text, Text) -> None
+        self.component = component
+        self.language = language
+
+        super(NoLanguageSupportingError, self).__init__(component, language)
+
+    def __str__(self):
+        return "component {} does not support language {}".format(
+            self.component, self.language
+        )
 
 
 class Component(object):
@@ -207,7 +223,7 @@ class Component(object):
         language = config.get('language', None)
         if not cls.can_handle_language(language):
             # check failed
-            raise NoLanguageSupportingError("component {} does not support language {}".format(cls.name, language))
+            raise NoLanguageSupportingError(cls.name, language)
 
         return cls()
 

--- a/rasa_nlu/components.py
+++ b/rasa_nlu/components.py
@@ -103,6 +103,22 @@ class MissingArgumentError(ValueError):
         return self.message
 
 
+class NoLanguageSupportingError(ValueError):
+    """Raised when a component is created but the language is not supported.
+
+    Attributes:
+        message -- explanation of which parameter is missing
+    """
+
+    def __init__(self, message):
+        # type: (Text) -> None
+        super(NoLanguageSupportingError, self).__init__(message)
+        self.message = message
+
+    def __str__(self):
+        return self.message
+
+
 class Component(object):
     """A component is a message processing unit in a pipeline.
 
@@ -202,7 +218,7 @@ class Component(object):
         language = config.get('language', None)
         if not cls.can_handle_language(language):
             # check failed
-            raise Exception("component {} does not support language {}".format(cls.name, language))
+            raise NoLanguageSupportingError("component {} does not support language {}".format(cls.name, language))
 
         return cls()
 

--- a/rasa_nlu/components.py
+++ b/rasa_nlu/components.py
@@ -148,7 +148,7 @@ class Component(object):
     # Default value is None which means it can handle all languages.
     # This is important feature that can backward-compatible with
     # old style components.
-    _language_list = None
+    language_list = None
 
     def __init__(self):
         self.partial_processing_pipeline = None
@@ -197,6 +197,13 @@ class Component(object):
         """Creates this component (e.g. before a training is started).
 
         Method can access all configuration parameters."""
+
+        # Check language supporting
+        language = config.get('language', None)
+        if not cls.can_handle_language(language):
+            # check failed
+            raise Exception("component {} not support language {}".format(cls.name, language))
+
         return cls()
 
     def provide_context(self):
@@ -285,17 +292,18 @@ class Component(object):
                         "to missing pipeline.")
         return message
 
-    def can_handle_language(self, language):
+    @classmethod
+    def can_handle_language(cls, language):
         # type: (Hashable) -> bool
         """Check if component support specific language.
 
         this method can overwrite when needed.
         (e.g. dynamic determine which language is supported.)"""
 
-        if self._language_list is None:  # None means support all languages
+        if cls.language_list is None:  # None means support all languages
             return True
 
-        return language in self._language_list
+        return language in cls.language_list
 
 
 class ComponentBuilder(object):

--- a/rasa_nlu/components.py
+++ b/rasa_nlu/components.py
@@ -103,20 +103,9 @@ class MissingArgumentError(ValueError):
         return self.message
 
 
-class NoLanguageSupportingError(ValueError):
-    """Raised when a component is created but the language is not supported.
-
-    Attributes:
-        message -- explanation of which parameter is missing
-    """
-
-    def __init__(self, message):
-        # type: (Text) -> None
-        super(NoLanguageSupportingError, self).__init__(message)
-        self.message = message
-
-    def __str__(self):
-        return self.message
+class NoLanguageSupportingError(Exception):
+    """Raised when a component is created but the language is not supported."""
+    pass
 
 
 class Component(object):

--- a/rasa_nlu/config.py
+++ b/rasa_nlu/config.py
@@ -52,7 +52,8 @@ DEFAULT_CONFIG = {
     "intent_classifier_sklearn": {
         "C": [1, 2, 5, 10, 20, 100],
         "kernel": "linear"
-    }
+    },
+    "component_force_language_support": False,
 }
 
 

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -261,6 +261,18 @@ class Interpreter(object):
                 raise Exception("Failed to initialize component '{}'. "
                                 "{}".format(component.name, e))
 
+        # Check language supporting
+        language = config.get('language')
+        for component in pipeline:
+            if not component.can_handle_language(language):
+                # check failed
+                raise Exception(
+                    "component {} not support language {}".format(
+                        component.name,
+                        language
+                    )
+                )
+
         return Interpreter(pipeline, context, model_metadata)
 
     def __init__(self, pipeline, context, model_metadata=None):

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -261,29 +261,7 @@ class Interpreter(object):
                 raise Exception("Failed to initialize component '{}'. "
                                 "{}".format(component.name, e))
 
-        # TODO: using explict class name is a bad idea
-        Interpreter.check_component_language(
-            pipeline,
-            language=config.get("language")
-        )
-
         return Interpreter(pipeline, context, model_metadata)
-
-    @staticmethod
-    def check_component_language(pipeline, language):
-        # type: (List, object) -> bool
-        """Check language supporting"""
-        for component in pipeline:
-            if not component.can_handle_language(language):
-                # check failed
-                raise Exception(
-                    "component {} not support language {}".format(
-                        component.name,
-                        language
-                    )
-                )
-
-        return True
 
     def __init__(self, pipeline, context, model_metadata=None):
         # type: (List[Component], Dict[Text, Any], Optional[Metadata]) -> None

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -225,8 +225,8 @@ class Interpreter(object):
         return Interpreter.create(model_metadata, config, component_builder,
                                   skip_valdation)
 
-    @classmethod
-    def create(cls, model_metadata,  # type: Metadata
+    @staticmethod
+    def create(model_metadata,  # type: Metadata
                config,  # type: RasaNLUConfig
                component_builder=None,  # type: Optional[ComponentBuilder]
                skip_valdation=False  # type: bool
@@ -261,13 +261,18 @@ class Interpreter(object):
                 raise Exception("Failed to initialize component '{}'. "
                                 "{}".format(component.name, e))
 
-        cls.check_component_language(pipeline, language=config.get("language"))
+        # TODO: using explict class name is a bad idea
+        Interpreter.check_component_language(
+            pipeline,
+            language=config.get("language")
+        )
 
         return Interpreter(pipeline, context, model_metadata)
 
-    @classmethod
-    def check_component_language(cls, pipeline, language):
-        # Check language supporting
+    @staticmethod
+    def check_component_language(pipeline, language):
+        # type: (List, object) -> bool
+        """Check language supporting"""
         for component in pipeline:
             if not component.can_handle_language(language):
                 # check failed

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -140,7 +140,7 @@ class Trainer(object):
                 # component don't support current language
                 if not config.component_force_language_support:
                     # ignore this component
-                    logger.warning(e.message)
+                    logger.warning(e)
                     continue
 
                 # else re-raise the exception

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -225,8 +225,8 @@ class Interpreter(object):
         return Interpreter.create(model_metadata, config, component_builder,
                                   skip_valdation)
 
-    @staticmethod
-    def create(model_metadata,  # type: Metadata
+    @classmethod
+    def create(cls, model_metadata,  # type: Metadata
                config,  # type: RasaNLUConfig
                component_builder=None,  # type: Optional[ComponentBuilder]
                skip_valdation=False  # type: bool
@@ -261,8 +261,13 @@ class Interpreter(object):
                 raise Exception("Failed to initialize component '{}'. "
                                 "{}".format(component.name, e))
 
+        cls.check_component_language(pipeline, language=config.get("language"))
+
+        return Interpreter(pipeline, context, model_metadata)
+
+    @classmethod
+    def check_component_language(cls, pipeline, language):
         # Check language supporting
-        language = config.get('language')
         for component in pipeline:
             if not component.can_handle_language(language):
                 # check failed
@@ -273,7 +278,7 @@ class Interpreter(object):
                     )
                 )
 
-        return Interpreter(pipeline, context, model_metadata)
+        return True
 
     def __init__(self, pipeline, context, model_metadata=None):
         # type: (List[Component], Dict[Text, Any], Optional[Metadata]) -> None

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -122,12 +122,20 @@ class Trainer(object):
         if not self.skip_validation:
             components.validate_requirements(config.pipeline)
 
-        # Transform the passed names of the pipeline components into classes
+        # build pipeline
+        self.pipeline = self._build_pipeline(config, component_builder)
+
+    @staticmethod
+    def _build_pipeline(config, component_builder):
+        # type: (RasaNLUConfig, ComponentBuilder) -> List
+        """Transform the passed names of the pipeline components into classes"""
+        pipeline = []
+
         for component_name in config.pipeline:
             try:
                 component = component_builder.create_component(
                         component_name, config)
-                self.pipeline.append(component)
+                pipeline.append(component)
             except NoLanguageSupportingError as e:
                 # component don't support current language
                 if not config.component_force_language_support:
@@ -137,6 +145,8 @@ class Trainer(object):
 
                 # else re-raise the exception
                 raise
+
+        return pipeline
 
     def train(self, data):
         # type: (TrainingData) -> Interpreter

--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -129,7 +129,9 @@ class Trainer(object):
                         component_name, config)
                 self.pipeline.append(component)
             except NoLanguageSupportingError as e:
+                # component don't support current language
                 if not config.component_force_language_support:
+                    # ignore this component
                     logger.warning(e.message)
                     continue
 

--- a/sample_configs/config_defaults.json
+++ b/sample_configs/config_defaults.json
@@ -37,5 +37,7 @@
   "intent_classifier_sklearn": {
     "C": [1, 2, 5, 10, 20, 100],
     "kernel": "linear"
-  }
+  },
+
+  "component_force_language_support": false
 }


### PR DESCRIPTION
New feature: component can specify languages it handles and can check language supporting before create a component.

**work in progress** and try to fix #477 

**Proposed changes**:
- Add new attribute `language_list` to `Component` class
- Add new method `can_handle_language` to `Component` class
- Add checking language supporting function in `create` class-method to `Component` class
- Add `component_force_language_support` to config, which user can define the behave when one component not support current language
- Add new exception type `NoLanguageSupportingError `
- Add try-catch block in `_build_pipeline ` method to `Trainer` class, to catch `NoLanguageSupportingError ` exception

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
