### PR TITLE
Filter out pre-trained entities before CRF entity training

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,8 @@ Changed
   of ``"None"`` as intent name in the json result if there's no match
 - in teh evaluation results, replaced ``O`` with the string
   ``no_entity`` for better understanding
+- The ``CRFEntityExtractor`` now only trains entity examples that have
+  ``"extractor": "ner_crf"`` or no extractor at all
 
 Fixed
 -----

--- a/rasa_nlu/extractors/__init__.py
+++ b/rasa_nlu/extractors/__init__.py
@@ -3,12 +3,16 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Text
 
 from rasa_nlu.components import Component
+
+if typing.TYPE_CHECKING:
+    from rasa_nlu.training_data import Message
 
 
 class EntityExtractor(Component):
@@ -25,3 +29,14 @@ class EntityExtractor(Component):
         else:
             entity["processors"] = [self.name]
         return entity
+
+    def filter_trainable_entities(self, entity_examples):
+        # type: (List[Message]) -> TrainingData
+        for message in entity_examples:
+            entities = []
+            for ent in message.get("entities", []):
+                extractor = ent.get("extractor")
+                if not extractor or extractor == self.name:
+                    entities.append(ent)
+            message.set("entities", entities)
+        return entity_examples

--- a/rasa_nlu/extractors/__init__.py
+++ b/rasa_nlu/extractors/__init__.py
@@ -3,18 +3,13 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from copy import deepcopy
-
-import typing
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Text
 
 from rasa_nlu.components import Component
-
-if typing.TYPE_CHECKING:
-    from rasa_nlu.training_data import Message
+from rasa_nlu.training_data import Message
 
 
 class EntityExtractor(Component):
@@ -34,12 +29,17 @@ class EntityExtractor(Component):
 
     def filter_trainable_entities(self, entity_examples):
         # type: (List[Message]) -> List[Message]
-        working_examples = deepcopy(entity_examples)
-        for message in working_examples:
+        filtered = []
+        for message in entity_examples:
             entities = []
             for ent in message.get("entities", []):
                 extractor = ent.get("extractor")
                 if not extractor or extractor == self.name:
                     entities.append(ent)
-            message.set("entities", entities)
-        return working_examples
+            data = message.data.copy()
+            data['entities'] = entities
+            filtered.append(Message(text=message.text,
+                                    data=data,
+                                    output_properties=message.output_properties,
+                                    time=message.time))
+        return filtered

--- a/rasa_nlu/extractors/__init__.py
+++ b/rasa_nlu/extractors/__init__.py
@@ -25,10 +25,17 @@ class EntityExtractor(Component):
             entity["processors"].append(self.name)
         else:
             entity["processors"] = [self.name]
+
         return entity
 
     def filter_trainable_entities(self, entity_examples):
         # type: (List[Message]) -> List[Message]
+        """Filters out untrainable entity annotations.
+
+        Creates a copy of entity_examples in which entities that have
+        `extractor` set to something other than self.name (e.g. 'ner_crf')
+        are removed."""
+
         filtered = []
         for message in entity_examples:
             entities = []
@@ -38,8 +45,10 @@ class EntityExtractor(Component):
                     entities.append(ent)
             data = message.data.copy()
             data['entities'] = entities
-            filtered.append(Message(text=message.text,
-                                    data=data,
-                                    output_properties=message.output_properties,
-                                    time=message.time))
+            filtered.append(
+                Message(text=message.text,
+                        data=data,
+                        output_properties=message.output_properties,
+                        time=message.time))
+
         return filtered

--- a/rasa_nlu/extractors/__init__.py
+++ b/rasa_nlu/extractors/__init__.py
@@ -3,6 +3,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from copy import deepcopy
+
 import typing
 from typing import Any
 from typing import Dict
@@ -31,7 +33,7 @@ class EntityExtractor(Component):
         return entity
 
     def filter_trainable_entities(self, entity_examples):
-        # type: (List[Message]) -> TrainingData
+        # type: (List[Message]) -> List[Message]
         for message in entity_examples:
             entities = []
             for ent in message.get("entities", []):

--- a/rasa_nlu/extractors/__init__.py
+++ b/rasa_nlu/extractors/__init__.py
@@ -34,11 +34,12 @@ class EntityExtractor(Component):
 
     def filter_trainable_entities(self, entity_examples):
         # type: (List[Message]) -> List[Message]
-        for message in entity_examples:
+        working_examples = deepcopy(entity_examples)
+        for message in working_examples:
             entities = []
             for ent in message.get("entities", []):
                 extractor = ent.get("extractor")
                 if not extractor or extractor == self.name:
                     entities.append(ent)
             message.set("entities", entities)
-        return entity_examples
+        return working_examples

--- a/rasa_nlu/extractors/crf_entity_extractor.py
+++ b/rasa_nlu/extractors/crf_entity_extractor.py
@@ -98,14 +98,13 @@ class CRFEntityExtractor(EntityExtractor):
 
         # checks whether there is at least one example with an entity annotation
         if training_data.entity_examples:
-            # entity examples are modified, hence create deepcopy
-            working_data = deepcopy(training_data.entity_examples)
             # filter out pre-trained entity examples
-            filtered = self.filter_trainable_entities(working_data)
+            filtered_entity_examples = self.filter_trainable_entities(
+                training_data.entity_examples)
             # convert the dataset into features
             # this will train on ALL examples, even the ones
             # without annotations
-            dataset = self._create_dataset(filtered)
+            dataset = self._create_dataset(filtered_entity_examples)
             # train the model
             self._train_model(dataset)
 

--- a/rasa_nlu/extractors/crf_entity_extractor.py
+++ b/rasa_nlu/extractors/crf_entity_extractor.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 import logging
 import os
-from copy import deepcopy
 
 import typing
 from typing import Any
@@ -18,7 +17,6 @@ from typing import Tuple
 from rasa_nlu.config import RasaNLUConfig
 from rasa_nlu.extractors import EntityExtractor
 from rasa_nlu.model import Metadata
-from rasa_nlu.tokenizers import Token
 from rasa_nlu.training_data import Message
 from rasa_nlu.training_data import TrainingData
 from builtins import str
@@ -28,7 +26,6 @@ logger = logging.getLogger(__name__)
 if typing.TYPE_CHECKING:
     from spacy.language import Language
     import sklearn_crfsuite
-    from spacy.tokens import Doc
 
 
 class CRFEntityExtractor(EntityExtractor):

--- a/rasa_nlu/extractors/crf_entity_extractor.py
+++ b/rasa_nlu/extractors/crf_entity_extractor.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import logging
 import os
+from copy import deepcopy
 
 import typing
 from typing import Any
@@ -97,9 +98,10 @@ class CRFEntityExtractor(EntityExtractor):
 
         # checks whether there is at least one example with an entity annotation
         if training_data.entity_examples:
+            # entity examples are modified, hence create deepcopy
+            working_data = deepcopy(training_data.entity_examples)
             # filter out pre-trained entity examples
-            filtered = self.filter_trainable_entities(
-                training_data.training_examples)
+            filtered = self.filter_trainable_entities(working_data)
             # convert the dataset into features
             # this will train on ALL examples, even the ones
             # without annotations

--- a/rasa_nlu/extractors/crf_entity_extractor.py
+++ b/rasa_nlu/extractors/crf_entity_extractor.py
@@ -97,10 +97,13 @@ class CRFEntityExtractor(EntityExtractor):
 
         # checks whether there is at least one example with an entity annotation
         if training_data.entity_examples:
+            # filter out pre-trained entity examples
+            filtered = self.filter_trainable_entities(
+                training_data.training_examples)
             # convert the dataset into features
             # this will train on ALL examples, even the ones
             # without annotations
-            dataset = self._create_dataset(training_data.training_examples)
+            dataset = self._create_dataset(filtered)
             # train the model
             self._train_model(dataset)
 

--- a/tests/base/test_extractors.py
+++ b/tests/base/test_extractors.py
@@ -38,8 +38,15 @@ def test_crf_extractor(spacy_nlp):
     sentence = 'anywhere in the west'
     ext.extract_entities(Message(sentence, {"spacy_doc": spacy_nlp(sentence)}))
     filtered = ext.filter_trainable_entities(examples)
+    assert filtered[0].get('entities') == [
+        {"start": 16, "end": 20, "value": "west", "entity": "location"}
+    ], 'Entity without extractor remains'
     assert filtered[1].get('entities') == [
-        {"start": 8, "end": 14, "value": "indian", "entity": "cuisine", "extractor": "ner_crf"}]
+        {"start": 8, "end": 14, "value": "indian", "entity": "cuisine", "extractor": "ner_crf"}
+    ], 'Only ner_crf entity annotation remains'
+    assert examples[1].get('entities')[0] == {
+        "start": 0, "end": 7, "value": "central", "entity": "location", "extractor": "random_extractor"
+    }, 'Original examples are not mutated'
 
 
 def test_crf_json_from_BILOU(spacy_nlp):

--- a/tests/base/test_extractors.py
+++ b/tests/base/test_extractors.py
@@ -38,7 +38,8 @@ def test_crf_extractor(spacy_nlp):
     sentence = 'anywhere in the west'
     ext.extract_entities(Message(sentence, {"spacy_doc": spacy_nlp(sentence)}))
     filtered = ext.filter_trainable_entities(examples)
-    assert filtered[1].get('entities') == [{"start": 8, "end": 14, "value": "indian", "entity": "cuisine", "extractor": "ner_crf"}]
+    assert filtered[1].get('entities') == [
+        {"start": 8, "end": 14, "value": "indian", "entity": "cuisine", "extractor": "ner_crf"}]
 
 
 def test_crf_json_from_BILOU(spacy_nlp):

--- a/tests/base/test_extractors.py
+++ b/tests/base/test_extractors.py
@@ -20,7 +20,10 @@ def test_crf_extractor(spacy_nlp):
         }),
         Message("central indian restaurant", {
             "intent": "restaurant_search",
-            "entities": [{"start": 0, "end": 7, "value": "central", "entity": "location"}],
+            "entities": [
+                {"start": 0, "end": 7, "value": "central", "entity": "location", "extractor": "random_extractor"},
+                {"start": 8, "end": 14, "value": "indian", "entity": "cuisine", "extractor": "ner_crf"}
+            ],
             "spacy_doc": spacy_nlp("central indian restaurant")
         })]
     config = {"ner_crf": {"BILOU_flag": True, "features": ext.crf_features}}
@@ -34,6 +37,8 @@ def test_crf_extractor(spacy_nlp):
     assert feats[1]['0:low'] == "in"
     sentence = 'anywhere in the west'
     ext.extract_entities(Message(sentence, {"spacy_doc": spacy_nlp(sentence)}))
+    filtered = ext.filter_trainable_entities(examples)
+    assert filtered[1].get('entities') == [{"start": 8, "end": 14, "value": "indian", "entity": "cuisine", "extractor": "ner_crf"}]
 
 
 def test_crf_json_from_BILOU(spacy_nlp):


### PR DESCRIPTION
**Proposed changes**:
- ``Extractor`` objects have the option to filter out pretrained entity examples
- implemented in the ``CRFEntityExtractor``

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
