### PR TITLE
Timestamps from metadata

### DIFF
--- a/rasa_nlu/project.py
+++ b/rasa_nlu/project.py
@@ -143,7 +143,7 @@ class Project(object):
 
         if models:
             time_list = [
-                datetime.datetime.strptime(m,'%Y%m%d-%H%M%S')
+                datetime.datetime.strptime(m, '%Y%m%d-%H%M%S')
                 for m in models]
             return models[max(time_list).strftime('%Y%m%d-%H%M%S')]
         else:

--- a/rasa_nlu/project.py
+++ b/rasa_nlu/project.py
@@ -131,14 +131,20 @@ class Project(object):
         return unloaded_model
 
     def _latest_project_model(self):
-        """Retrieves the latest trained model for an project"""
+        """Retrieves the latest trained model for a project"""
 
-        models = {model[len(MODEL_NAME_PREFIX):]: model
-                  for model in self._models.keys()
-                  if model.startswith(MODEL_NAME_PREFIX)}
+        models = {}
+        for model in self._models.keys():
+            try:
+                key = self._read_model_metadata(model).metadata.get("trained_at")
+                models[key] = model
+            except:
+                logger.warn("Failed to read metadata for model {}".format(model))
+
         if models:
-            time_list = [datetime.datetime.strptime(time, '%Y%m%d-%H%M%S')
-                         for time, model in models.items()]
+            time_list = [
+                datetime.datetime.strptime(m,'%Y%m%d-%H%M%S')
+                for m in models]
             return models[max(time_list).strftime('%Y%m%d-%H%M%S')]
         else:
             return FALLBACK_MODEL_NAME


### PR DESCRIPTION
**Proposed changes**:
- use `trained_at` timestamps from `metadata.json` rather than model dir names to choose 'latest' model.
- currently, if a project has models saved as e.g. `projects/default/mymodelname`, calls to `/parse` will be served with the keyword interpreter rather than the most recent model in the project dir. This PR fixes that

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
