### PR TITLE
Unload unused models from server memory

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Added
 - added ability to list projects in cloud storage services for model loading
 - server evaluation endpoint at ``POST /evaluate``
 - CRF entity recognizer now returns a confidence score when extracting entities
+- server endpoint at ``DELETE /models`` to unload models from server memory
 
 Changed
 -------

--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -351,15 +351,15 @@ class DataRouter(object):
         # type: (Text, Text) -> Dict[Text]
         """Unload a model from server memory."""
 
-        project = project or RasaNLUConfig.DEFAULT_PROJECT_NAME
-
-        if project not in self.project_store:
+        if project is None:
+            raise InvalidProjectError("No project specified".format(project))
+        elif project not in self.project_store:
             raise InvalidProjectError("Project {} could not "
                                       "be found".format(project))
 
         try:
             unloaded_model = self.project_store[project].unload(model)
-            return {"unloaded_model": unloaded_model}
+            return unloaded_model
         except KeyError:
             raise InvalidProjectError("Failed to unload model {} "
                                       "for project {}.".format(model, project))

--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -346,3 +346,20 @@ class DataRouter(object):
                 "f1_score": f1,
                 "accuracy": accuracy}
         }
+
+    def unload_model(self, project, model):
+        # type: (Text, Text) -> Dict[Text]
+        """Unload a model from server memory."""
+
+        project = project or RasaNLUConfig.DEFAULT_PROJECT_NAME
+
+        if project not in self.project_store:
+            raise InvalidProjectError("Project {} could not "
+                                      "be found".format(project))
+
+        try:
+            unloaded_model = self.project_store[project].unload(model)
+            return {"unloaded_model": unloaded_model}
+        except KeyError:
+            raise InvalidProjectError("Failed to unload model {} "
+                                      "for project {}.".format(model, project))

--- a/rasa_nlu/project.py
+++ b/rasa_nlu/project.py
@@ -184,7 +184,13 @@ class Project(object):
 
     def as_dict(self):
         return {'status': 'training' if self.status else 'ready',
-                'available_models': list(self._models.keys())}
+                'available_models': list(self._models.keys()),
+                'loaded_models': self._list_loaded_models()}
+
+    def _list_loaded_models(self):
+        return [
+            model for model, interpreter in self._models.items() if interpreter
+        ]
 
     def _list_models_in_cloud(self, config):
         # type: (RasaNLUConfig) -> List[Text]

--- a/rasa_nlu/project.py
+++ b/rasa_nlu/project.py
@@ -129,9 +129,10 @@ class Project(object):
         self._writer_lock.acquire()
         try:
             del self._models[model_name]
+            self._models[model_name] = None
+            return model_name
         finally:
             self._writer_lock.release()
-            return model_name
 
     def _latest_project_model(self):
         """Retrieves the latest trained model for an project"""

--- a/rasa_nlu/project.py
+++ b/rasa_nlu/project.py
@@ -127,9 +127,11 @@ class Project(object):
 
     def unload(self, model_name):
         self._writer_lock.acquire()
-        unloaded_model = self._models.pop(model_name)
-        self._writer_lock.release()
-        return unloaded_model
+        try:
+            del self._models[model_name]
+        finally:
+            self._writer_lock.release()
+            return model_name
 
     def _latest_project_model(self):
         """Retrieves the latest trained model for an project"""

--- a/rasa_nlu/project.py
+++ b/rasa_nlu/project.py
@@ -189,9 +189,11 @@ class Project(object):
                 'loaded_models': self._list_loaded_models()}
 
     def _list_loaded_models(self):
-        return [
-            model for model, interpreter in self._models.items() if interpreter
-        ]
+        models = []
+        for model, interpreter in self._models.items():
+            if interpreter is not None:
+                models.append(model)
+        return models
 
     def _list_models_in_cloud(self, config):
         # type: (RasaNLUConfig) -> List[Text]

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -245,11 +245,14 @@ class RasaNLU(object):
         request.setHeader('Content-Type', 'application/json')
         try:
             request.setResponseCode(200)
-            response = self.data_router.unload_model(params.get('project'),
-                                                     params.get('model'))
+            response = self.data_router.unload_model(
+                params.get('project', RasaNLUConfig.DEFAULT_PROJECT_NAME),
+                params.get('model')
+            )
             return simplejson.dumps(response)
         except Exception as e:
             request.setResponseCode(500)
+            logger.exception(e)
             return simplejson.dumps({"error": "{}".format(e)})
 
 

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -223,12 +223,30 @@ class RasaNLU(object):
         }
 
         request.setHeader('Content-Type', 'application/json')
-
         try:
             request.setResponseCode(200)
             response = self.data_router.evaluate(data_string,
                                                  params.get('project'),
                                                  params.get('model'))
+            return simplejson.dumps(response)
+        except Exception as e:
+            request.setResponseCode(500)
+            return simplejson.dumps({"error": "{}".format(e)})
+
+    @app.route("/models", methods=['DELETE'])
+    @requires_auth
+    @check_cors
+    def unload_model(self, request):
+        params = {
+            key.decode('utf-8', 'strict'): value[0].decode('utf-8', 'strict')
+            for key, value in request.args.items()
+        }
+
+        request.setHeader('Content-Type', 'application/json')
+        try:
+            request.setResponseCode(200)
+            response = self.data_router.unload_model(params.get('project'),
+                                                     params.get('model'))
             return simplejson.dumps(response)
         except Exception as e:
             request.setResponseCode(500)

--- a/tests/base/test_multitenancy.py
+++ b/tests/base/test_multitenancy.py
@@ -107,6 +107,7 @@ def test_post_parse_specific_model(app):
                                   "model": model})
     response = yield app.post(query.endpoint, json=query.payload)
     assert response.code == 200
+    assert model in project["loaded_models"]
 
 
 @pytest.mark.parametrize("response_test", [

--- a/tests/base/test_server.py
+++ b/tests/base/test_server.py
@@ -245,4 +245,4 @@ def test_unload_fallback(app):
     response = yield app.delete(unload)
     rjs = yield response.json()
     assert response.code == 200, "Fallback model unloaded"
-    assert rjs == {"unloaded_model": "fallback"}
+    assert rjs == "fallback"

--- a/tests/base/test_server.py
+++ b/tests/base/test_server.py
@@ -235,7 +235,6 @@ def test_unload_model_error(app):
     model_err = "http://dummy-uri/models?model=my_model"
     response = yield app.delete(model_err)
     rjs = yield response.json()
-    print(rjs)
     assert response.code == 500, "Model not found"
     assert rjs['error'] == "Failed to unload model my_model for project default."
 

--- a/tests/base/test_server.py
+++ b/tests/base/test_server.py
@@ -222,3 +222,27 @@ def test_evaluate(app, rasa_default_train_data):
                                                              "precision",
                                                              "f1_score",
                                                              "accuracy"])
+
+
+@pytest.inlineCallbacks
+def test_unload_model_error(app):
+    project_err = "http://dummy-uri/models?project=my_project&model=my_model"
+    response = yield app.delete(project_err)
+    rjs = yield response.json()
+    assert response.code == 500, "Project not found"
+    assert rjs['error'] == "Project my_project could not be found"
+
+    model_err = "http://dummy-uri/models?model=my_model"
+    response = yield app.delete(model_err)
+    rjs = yield response.json()
+    assert response.code == 500, "Model not found"
+    assert rjs['error'] == "Failed to unload model my_model for project default."
+
+
+@pytest.inlineCallbacks
+def test_unload_fallback(app):
+    unload = "http://dummy-uri/models?model=fallback"
+    response = yield app.delete(unload)
+    rjs = yield response.json()
+    assert response.code == 200, "Fallback model unloaded"
+    assert rjs == {"unloaded_model": "fallback"}

--- a/tests/base/test_server.py
+++ b/tests/base/test_server.py
@@ -235,6 +235,7 @@ def test_unload_model_error(app):
     model_err = "http://dummy-uri/models?model=my_model"
     response = yield app.delete(model_err)
     rjs = yield response.json()
+    print(rjs)
     assert response.code == 500, "Model not found"
     assert rjs['error'] == "Failed to unload model my_model for project default."
 


### PR DESCRIPTION
**Proposed changes**:
- only ever keep one model per project in the server's memory under `Project._models`
- unload previous NLU model from `Project` when a new model is requested by the server

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
