### PR TITLE
Add basic Dependancy parser

### DIFF
--- a/rasa_nlu/extractors/spacy_dep_extractor.py
+++ b/rasa_nlu/extractors/spacy_dep_extractor.py
@@ -29,12 +29,16 @@ class SpacyDependancyExtractor(EntityExtractor):
         updated_entities = message.get("entities", [])[:]
         doc = message.get("spacy_doc")
 
-        for token in doc:
-            for entity in updated_entities:
-                entity_value = str(entity["value"]).lower()
+        self.parse_dependencies(doc, updated_entities)
+        message.set("entities", updated_entities, add_to_output=True)
 
-                if entity_value.find(token.text) != -1 and token.head.pos_ == 'ADP':
+    def parse_dependencies(self, doc, entities):
+        for token in doc:
+            for entity in entities:
+                entity_value = str(entity["value"]).lower()
+                token_found = entity_value.find(token.text) != -1
+                token_ad = token.head.pos_ == 'ADP'
+
+                if token_found and token_ad:
                     entity["adposition"] = token.head.text
                     self.add_processor_name(entity)
-
-        message.set("entities", updated_entities, add_to_output=True)

--- a/rasa_nlu/extractors/spacy_dependancy_extractor.py
+++ b/rasa_nlu/extractors/spacy_dependancy_extractor.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import typing
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Text
+
+from rasa_nlu.extractors import EntityExtractor
+from rasa_nlu.training_data import Message
+
+if typing.TYPE_CHECKING:
+    from spacy.tokens.doc import Doc
+
+
+class SpacyDependancyExtractor(EntityExtractor):
+    name = "dep_spacy"
+
+    provides = ["entities"]
+
+    requires = ["spacy_nlp"]
+
+    def process(self, message, **kwargs):
+        # type: (Message, **Any) -> None
+
+        updated_entities = message.get("entities", [])[:]
+        doc = message.get("spacy_doc")
+
+        for token in doc:
+            for entity in updated_entities:
+                entity_value = str(entity["value"]).lower()
+
+                if entity_value.find(token.text) != -1 and token.head.pos_ == 'ADP':
+                    entity["adposition"] = token.head.text
+                    self.add_processor_name(entity)
+
+        message.set("entities", updated_entities, add_to_output=True)

--- a/rasa_nlu/registry.py
+++ b/rasa_nlu/registry.py
@@ -21,7 +21,7 @@ from rasa_nlu.extractors.duckling_extractor import DucklingExtractor
 from rasa_nlu.extractors.duckling_http_extractor import DucklingHTTPExtractor
 from rasa_nlu.extractors.entity_synonyms import EntitySynonymMapper
 from rasa_nlu.extractors.spacy_entity_extractor import SpacyEntityExtractor
-from rasa_nlu.extractors.spacy_dependancy_extractor import SpacyDependancyExtractor
+from rasa_nlu.extractors.spacy_dep_extractor import SpacyDependancyExtractor
 from rasa_nlu.featurizers.ngram_featurizer import NGramFeaturizer
 from rasa_nlu.featurizers.regex_featurizer import RegexFeaturizer
 from rasa_nlu.featurizers.spacy_featurizer import SpacyFeaturizer

--- a/rasa_nlu/registry.py
+++ b/rasa_nlu/registry.py
@@ -21,6 +21,7 @@ from rasa_nlu.extractors.duckling_extractor import DucklingExtractor
 from rasa_nlu.extractors.duckling_http_extractor import DucklingHTTPExtractor
 from rasa_nlu.extractors.entity_synonyms import EntitySynonymMapper
 from rasa_nlu.extractors.spacy_entity_extractor import SpacyEntityExtractor
+from rasa_nlu.extractors.spacy_dependancy_extractor import SpacyDependancyExtractor
 from rasa_nlu.featurizers.ngram_featurizer import NGramFeaturizer
 from rasa_nlu.featurizers.regex_featurizer import RegexFeaturizer
 from rasa_nlu.featurizers.spacy_featurizer import SpacyFeaturizer
@@ -50,7 +51,7 @@ component_classes = [
     CountVectorsFeaturizer,
     SpacyTokenizer, WhitespaceTokenizer,
     SklearnIntentClassifier, KeywordIntentClassifier,
-    EmbeddingIntentClassifier
+    EmbeddingIntentClassifier, SpacyDependancyExtractor
 ]
 
 # Mapping from a components name to its class to allow name based lookup.
@@ -67,6 +68,7 @@ registered_pipeline_templates = {
         "intent_entity_featurizer_regex",
         "ner_crf",
         "ner_synonyms",
+        "dep_spacy",
         "intent_classifier_sklearn",
     ],
     "keyword": [
@@ -89,6 +91,7 @@ registered_pipeline_templates = {
         "ner_duckling",
         "ner_duckling_http",
         "ner_synonyms",
+        "dep_spacy",
         "intent_classifier_keyword",
         "intent_classifier_sklearn",
         "intent_classifier_tensorflow_embedding"


### PR DESCRIPTION
Trying to get from/to type coverage for entities. With the new component in the pipeline entities can look like this if they have pre/postpositions. Note the `adposition` value on each entity. Python is far from my first language so feel free to help me improve it. I'll add tests/docs if there is interest in merging it.

```
{
  "text":"I need a flight from San Francisco to London",
  "intent":{
    "name":"book_flight",
    "confidence":0.7092202519619129
  },
  "entities":[
    {
      "start":21,
      "end":34,
      "value":"san francisco",
      "entity":"location",
      "confidence":0.7393401167571362,
      "extractor":"ner_crf",
      "adposition":"from",
      "processors":[
        "dep_spacy"
      ]
    },
    {
      "start":38,
      "end":44,
      "value":"london",
      "entity":"location",
      "confidence":0.7607526517177635,
      "extractor":"ner_crf",
      "adposition":"to",
      "processors":[
        "dep_spacy"
      ]
    }
  ]
}
```

**Proposed changes**:
- added a processor which checks for ADP dependencies of entities

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog