### PR TITLE
Make evaluation script compatible with tensorflow classifier

### DIFF
--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -490,7 +490,7 @@ def remove_duckling_entities(entity_predictions):
         for e in entities:
             if e["extractor"] not in duckling_extractors:
                 patched_entities.append(e)
-            patched_entity_predictions.append(patched_entities)
+        patched_entity_predictions.append(patched_entities)
 
     return patched_entity_predictions
 

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -528,29 +528,6 @@ def patch_duckling(interpreter, extractors, entity_predictions):
     return extractors, entity_predictions
 
 
-def merge_duckling(results):
-    """Merges the results of the duckling exctractors"""
-
-    if any(results.keys().startswith('ner_duckling_http')):
-        duckling_http_results = defaultdict(list)
-        for k, v in {k: v for k, v in results if
-                     k.startswith('ner_duckling_http')}:
-            for key, val in v:
-                duckling_http_results[key] += val
-            results.remove(k)
-        results['ner_duckling_http'] = duckling_http_results
-
-    if any(results.keys().startswith('ner_duckling')):
-        duckling_results = {}
-        for k, v in {k: v for k, v in results if k.startswith('ner_duckling')}:
-            for key, val in v:
-                duckling_results[key] += val
-            results.remove(k)
-        results['ner_duckling'] = duckling_results
-
-    return results
-
-
 def run_evaluation(data_path, model_path,
                    component_builder=None):  # pragma: no cover
     """Evaluate intent classification and entity extraction."""
@@ -757,7 +734,6 @@ if __name__ == '__main__':  # pragma: no cover
         data = drop_intents_below_freq(data, cutoff=5)
         results, entity_results = run_cv_evaluation(
                 data, int(cmdline_args.folds), nlu_config)
-        entity_results = merge_duckling(entity_results)
         logger.info("CV evaluation (n={})".format(cmdline_args.folds))
 
         if any(results):

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -533,10 +533,8 @@ def run_evaluation(data_path, model_path,
     interpreter = Interpreter.load(model_path, component_builder)
     test_data = training_data.load_data(data_path,
                                         interpreter.model_metadata.language)
-
-    intent_targets = get_intent_targets(test_data)
-    intent_predictions = get_intent_predictions(interpreter, test_data)
     extractors = get_entity_extractors(interpreter)
+
     if extractors:
         entity_targets = get_entity_targets(test_data)
         entity_predictions, tokens = get_entity_predictions(interpreter,
@@ -549,6 +547,8 @@ def run_evaluation(data_path, model_path,
                           extractors)
 
     if get_intent_classifier(interpreter):
+        intent_targets = get_intent_targets(test_data)
+        intent_predictions = get_intent_predictions(interpreter, test_data)
         logger.info("Intent evaluation results:")
         evaluate_intents(intent_targets, intent_predictions)
 

--- a/rasa_nlu/extractors/crf_entity_extractor.py
+++ b/rasa_nlu/extractors/crf_entity_extractor.py
@@ -195,10 +195,12 @@ class CRFEntityExtractor(EntityExtractor):
         entity_label = self._entity_from_label(label)
 
         while not finished:
-            label, label_confidence = self.most_likely_entity(
-                    ent_word_idx, entities)
-
-            confidence = min(confidence, label_confidence)
+            try:
+                label, label_confidence = self.most_likely_entity(
+                        ent_word_idx, entities)
+                confidence = min(confidence, label_confidence)
+            except IndexError:
+                pass
 
             if len(entities) > ent_word_idx and label[2:] != entity_label:
                 # words are not tagged the same entity class

--- a/rasa_nlu/extractors/crf_entity_extractor.py
+++ b/rasa_nlu/extractors/crf_entity_extractor.py
@@ -149,7 +149,10 @@ class CRFEntityExtractor(EntityExtractor):
             return []
 
     def most_likely_entity(self, idx, entities):
-        entity_probs = entities[idx]
+        if len(entities) > idx:
+            entity_probs = entities[idx]
+        else:
+            entity_probs = None
         if entity_probs:
             label = max(entity_probs,
                         key=lambda key: entity_probs[key])
@@ -195,24 +198,22 @@ class CRFEntityExtractor(EntityExtractor):
         entity_label = self._entity_from_label(label)
 
         while not finished:
-            try:
-                label, label_confidence = self.most_likely_entity(
-                        ent_word_idx, entities)
-                confidence = min(confidence, label_confidence)
-            except IndexError:
-                pass
+            label, label_confidence = self.most_likely_entity(
+                    ent_word_idx, entities)
 
-            if len(entities) > ent_word_idx and label[2:] != entity_label:
+            confidence = min(confidence, label_confidence)
+
+            if label[2:] != entity_label:
                 # words are not tagged the same entity class
                 logger.debug("Inconsistent BILOU tagging found, B- tag, L- "
                              "tag pair encloses multiple entity classes.i.e. "
                              "[B-a, I-b, L-a] instead of [B-a, I-a, L-a].\n"
                              "Assuming B- class is correct.")
 
-            if len(entities) > ent_word_idx and label.startswith('L-'):
+            if label.startswith('L-'):
                 # end of the entity
                 finished = True
-            elif len(entities) > ent_word_idx and label.startswith('I-'):
+            elif label.startswith('I-'):
                 # middle part of the entity
                 ent_word_idx += 1
             else:

--- a/tests/base/test_evaluation.py
+++ b/tests/base/test_evaluation.py
@@ -10,10 +10,10 @@ import pytest
 
 from rasa_nlu.evaluate import (
     is_token_within_entity, do_entities_overlap,
-    merge_labels, patch_duckling_entities,
+    merge_labels, remove_duckling_entities,
     remove_empty_intent_examples, get_entity_extractors,
     get_duckling_dimensions, known_duckling_dimensions,
-    find_component, patch_duckling_extractors, drop_intents_below_freq,
+    find_component, remove_duckling_extractors, drop_intents_below_freq,
     run_cv_evaluation, substitute_labels)
 from rasa_nlu.evaluate import does_token_cross_borders
 from rasa_nlu.evaluate import align_entity_predictions
@@ -204,17 +204,9 @@ def test_duckling_patching():
             "value": "near Alexanderplatz",
             "entity": "location",
             "extractor": "ner_crf"
-        },
-        {
-            "start": 57,
-            "end": 64,
-            "value": "tonight",
-            "entity": "Time",
-            "extractor": "ner_duckling (Time)"
-
         }
     ]]
-    assert patch_duckling_entities(entities) == patched
+    assert remove_duckling_entities(entities) == patched
 
 
 def test_drop_intents_below_freq():
@@ -288,11 +280,10 @@ def test_find_component(duckling_interpreter):
     assert name == "ner_duckling"
 
 
-def test_patch_duckling_extractors(duckling_interpreter):
-    target = {"ner_duckling ({})".format(dim)
-              for dim in known_duckling_dimensions}
+def test_remove_duckling_extractors(duckling_interpreter):
+    target = {}
 
-    patched = patch_duckling_extractors(duckling_interpreter, {"ner_duckling"})
+    patched = remove_duckling_extractors(duckling_interpreter, {"ner_duckling"})
     assert patched == target
 
 

--- a/tests/base/test_evaluation.py
+++ b/tests/base/test_evaluation.py
@@ -283,7 +283,7 @@ def test_find_component(duckling_interpreter):
 def test_remove_duckling_extractors(duckling_interpreter):
     target = {}
 
-    patched = remove_duckling_extractors(duckling_interpreter, {"ner_duckling"})
+    patched = remove_duckling_extractors({"ner_duckling"})
     assert patched == target
 
 

--- a/tests/base/test_evaluation.py
+++ b/tests/base/test_evaluation.py
@@ -281,7 +281,7 @@ def test_find_component(duckling_interpreter):
 
 
 def test_remove_duckling_extractors(duckling_interpreter):
-    target = {}
+    target = set([])
 
     patched = remove_duckling_extractors({"ner_duckling"})
     assert patched == target


### PR DESCRIPTION
**Proposed changes**:
- Before, entity predictions were always extracted which isn't possible when only using the tensorflow classifier pipeline because it has no tokenizer. Now we check whether an intent classifier/entity extractor is present before running evaluation on either. (this also means no weird confusion matrix is generated when only evaluating an NER pipeline)
- We also skip evaluation of duckling
- Fixed the crf extractor 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
