### PR TITLE
text normalisation

### DIFF
--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -123,7 +123,7 @@ intent_featurizer_count_vectors
 :Outputs: nothing, used as an input to intent classifiers that need bag-of-words representation of intent features (e.g. ``intent_classifier_tensorflow_embedding``)
 :Description:
     Creates bag-of-words representation of intent features using
-    `sklearn's CountVectorizer <http://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.CountVectorizer.html>`_
+    `sklearn's CountVectorizer <http://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.CountVectorizer.html>`_. All tokens which consist only of digits (e.g. 123 and 99 but not a123d) will be assigned to the same feature.
 
 :Configuration:
     See `sklearn's CountVectorizer docs <http://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.CountVectorizer.html>`_

--- a/rasa_nlu/featurizers/count_vectors_featurizer.py
+++ b/rasa_nlu/featurizers/count_vectors_featurizer.py
@@ -29,7 +29,9 @@ class CountVectorsFeaturizer(Featurizer):
     """Bag of words featurizer
 
     Creates bag-of-words representation of intent features
-    using sklearn's `CountVectorizer`"""
+    using sklearn's `CountVectorizer`.
+    All tokens which consist only of digits (e.g. 123 and 99
+    but not ab12d) will be represented by a single feature."""
 
     name = "intent_featurizer_count_vectors"
 

--- a/rasa_nlu/featurizers/count_vectors_featurizer.py
+++ b/rasa_nlu/featurizers/count_vectors_featurizer.py
@@ -7,6 +7,7 @@ import logging
 import typing
 import os
 import io
+import re
 from future.utils import PY3
 from typing import Any, Dict, List, Optional, Text
 
@@ -98,6 +99,9 @@ class CountVectorsFeaturizer(Featurizer):
         # declare class instance for CountVect
         self.vect = None
 
+        # preprocessor
+        self.preprocessor = lambda s: re.sub(r'\b[0-9]+\b', 'NUMBER', s)
+
     @classmethod
     def required_packages(cls):
         # type: () -> List[Text]
@@ -117,7 +121,8 @@ class CountVectorsFeaturizer(Featurizer):
                                                  self.max_ngram),
                                     max_df=self.max_df,
                                     min_df=self.min_df,
-                                    max_features=self.max_features)
+                                    max_features=self.max_features,
+                                    preprocessor=self.preprocessor)
 
         lem_exs = [self._lemmatize(example)
                    for example in training_data.intent_examples]

--- a/tests/base/test_featurizers.py
+++ b/tests/base/test_featurizers.py
@@ -113,6 +113,7 @@ def test_spacy_featurizer_casing(spacy_nlp):
     ("hello hello hello hello hello ", [5]),
     ("hello goodbye hello", [1, 2]),
     ("a b c d e f", [1, 1, 1, 1, 1, 1]),
+    ("a 1 2", [2, 1])
 ])
 def test_count_vector_featurizer(sentence, expected):
     from rasa_nlu.featurizers.count_vectors_featurizer import \


### PR DESCRIPTION
**Proposed changes**:
- replace pure number tokens like `90210` with `NUMBER` in `countvectorfeaturizer`

questions:
- should this be configurable? is there any use case where different numbers might indicate a different intent?
- if we do this, it should obviously be well documented behaviour
- It might be an idea to also have a special `OOV` token (for test time) because e.g. a lot of unfamiliar words will likely indicate an out of scope utterance. Not as straightforward to implement bc as it's currently implemented all tokens in the training set are in the vocab (so no way for model to learn how to use what's in the OOV column)
@Ghostvv @akelad @tmbo 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
