### PR TITLE
push docs to docs branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
     - git config --global user.name "Travis CI"
     - git remote set-url --push origin "git@github.com:$TRAVIS_REPO_SLUG"
     - export ${!TRAVIS*}
-    - sphinx-versioning push docs gh-pages .
+    - sphinx-versioning push docs docs .
   - stage: deploy
     install: skip
     script: skip


### PR DESCRIPTION
**Proposed changes**:
- build docs onto the `docs` branch instead of `gh-pages` (this will allow us to deactivate github page hosting of the docs)
- fixes #998 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
