### PR TITLE
Preload the projects into the memory before starting the server

### DIFF
--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -93,8 +93,7 @@ class DataRouter(object):
                  emulation_mode=None,
                  remote_storage=None,
                  component_builder=None,
-                 load_all=False):
-        logger.debug('here2')
+                 pre_load=[]):
         self._training_processes = max(max_training_processes, 1)
         self.responses = self._create_query_logger(response_log)
         self.project_dir = config.make_path_absolute(project_dir)
@@ -109,9 +108,9 @@ class DataRouter(object):
         self.project_store = self._create_project_store(project_dir)
         self.pool = ProcessPool(self._training_processes)
         logger.debug('loading all2')
-        if (load_all):
-            logger.debug('loading all')
-            self._load_all()
+        if (pre_load):
+            logger.debug('Preloading....')
+            self._pre_load(pre_load)
 
     def __del__(self):
         """Terminates workers pool processes"""
@@ -175,8 +174,13 @@ class DataRouter(object):
                     remote_storage=self.remote_storage)
         return project_store
 
-    def _load_all(self):
+    def _pre_load(self, projects):
+        if 'all' in projects:
+            projects = self.project_store.keys()
+        logger.debug("loading %s", projects)
         for project in self.project_store:
+            if project not in projects:
+                continue
             logger.debug('Loading %s.....', project)
             out = self.project_store[project].load_model()
             if out:

--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -92,8 +92,9 @@ class DataRouter(object):
                  response_log=None,
                  emulation_mode=None,
                  remote_storage=None,
-                 component_builder=None):
-
+                 component_builder=None,
+                 load_all=False):
+        logger.debug('here2')
         self._training_processes = max(max_training_processes, 1)
         self.responses = self._create_query_logger(response_log)
         self.project_dir = config.make_path_absolute(project_dir)
@@ -107,6 +108,10 @@ class DataRouter(object):
 
         self.project_store = self._create_project_store(project_dir)
         self.pool = ProcessPool(self._training_processes)
+        logger.debug('loading all2')
+        if (load_all):
+            logger.debug('loading all')
+            self._load_all()
 
     def __del__(self):
         """Terminates workers pool processes"""
@@ -169,6 +174,16 @@ class DataRouter(object):
                     project_dir=self.project_dir,
                     remote_storage=self.remote_storage)
         return project_store
+
+    def _load_all(self):
+        for project in self.project_store:
+            logger.debug('Loading %s.....', project)
+            out = self.project_store[project].load_model()
+            if out:
+                logger.debug('Loaded successfully')
+            else:
+                logger.debug('Loading failed')
+        return None
 
     def _list_projects_in_cloud(self):
         try:

--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -92,8 +92,7 @@ class DataRouter(object):
                  response_log=None,
                  emulation_mode=None,
                  remote_storage=None,
-                 component_builder=None,
-                 pre_load=[]):
+                 component_builder=None):
         self._training_processes = max(max_training_processes, 1)
         self.responses = self._create_query_logger(response_log)
         self.project_dir = config.make_path_absolute(project_dir)
@@ -107,10 +106,6 @@ class DataRouter(object):
 
         self.project_store = self._create_project_store(project_dir)
         self.pool = ProcessPool(self._training_processes)
-        logger.debug('loading all2')
-        if (pre_load):
-            logger.debug('Preloading....')
-            self._pre_load(pre_load)
 
     def __del__(self):
         """Terminates workers pool processes"""
@@ -175,11 +170,9 @@ class DataRouter(object):
         return project_store
 
     def _pre_load(self, projects):
-        if 'all' in projects:
-            projects = self.project_store.keys()
         logger.debug("loading %s", projects)
         for project in self.project_store:
-            if project not in projects:
+            if project not in projects and 'all' not in projects:
                 continue
             logger.debug('Loading %s.....', project)
             out = self.project_store[project].load_model()

--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -172,13 +172,17 @@ class DataRouter(object):
     def _pre_load(self, projects):
         logger.debug("loading %s", projects)
         for project in self.project_store:
-            if project in projects or 'all' in projects:
-                logger.debug('Loading %s.....', project)
-                out = self.project_store[project].load_model()
-                if out:
-                    logger.debug('Loaded successfully')
-                else:
-                    logger.debug('Loading failed')
+            project_check = project not in projects
+            all_check = 'all' not in projects
+            if project_check and all_check:
+                continue
+            logger.debug('Loading %s.....', project)
+            out = self.project_store[project].load_model()
+            if out:
+                logger.debug('Loaded successfully')
+            else:
+                logger.debug('Loading failed')
+        return None
 
     def _list_projects_in_cloud(self):
         try:

--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -171,17 +171,8 @@ class DataRouter(object):
 
     def _pre_load(self, projects):
         logger.debug("loading %s", projects)
-        for project in self.project_store:
-            project_check = project not in projects
-            if project_check:
-                continue
-            logger.debug('Loading %s.....', project)
-            out = self.project_store[project].load_model()
-            if out:
-                logger.debug('Loaded successfully')
-            else:
-                logger.debug('Loading failed')
-        return None
+        filtered = [p for p in self.project_store if p in projects]
+        map(lambda p: self.project_store[p].load_model(), filtered)
 
     def _list_projects_in_cloud(self):
         try:

--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -171,8 +171,9 @@ class DataRouter(object):
 
     def _pre_load(self, projects):
         logger.debug("loading %s", projects)
-        filtered = [p for p in self.project_store if p in projects]
-        map(lambda p: self.project_store[p].load_model(), filtered)
+        for project in self.project_store:
+            if project in projects:
+                self.project_store[project].load_model()
 
     def _list_projects_in_cloud(self):
         try:

--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -173,8 +173,7 @@ class DataRouter(object):
         logger.debug("loading %s", projects)
         for project in self.project_store:
             project_check = project not in projects
-            all_check = 'all' not in projects
-            if project_check and all_check:
+            if project_check:
                 continue
             logger.debug('Loading %s.....', project)
             out = self.project_store[project].load_model()

--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -172,15 +172,13 @@ class DataRouter(object):
     def _pre_load(self, projects):
         logger.debug("loading %s", projects)
         for project in self.project_store:
-            if project not in projects and 'all' not in projects:
-                continue
-            logger.debug('Loading %s.....', project)
-            out = self.project_store[project].load_model()
-            if out:
-                logger.debug('Loaded successfully')
-            else:
-                logger.debug('Loading failed')
-        return None
+            if project in projects or 'all' in projects:
+                logger.debug('Loading %s.....', project)
+                out = self.project_store[project].load_model()
+                if out:
+                    logger.debug('Loaded successfully')
+                else:
+                    logger.debug('Loading failed')
 
     def _list_projects_in_cloud(self):
         try:

--- a/rasa_nlu/project.py
+++ b/rasa_nlu/project.py
@@ -130,7 +130,7 @@ class Project(object):
         self._begin_read()
         status = False
         model_name = self._dynamic_load_model()
-        logger.debug('Loaidng model %s', model_name)
+        logger.debug('Loading model %s', model_name)
 
         self._loader_lock.acquire()
         try:

--- a/rasa_nlu/project.py
+++ b/rasa_nlu/project.py
@@ -126,6 +126,25 @@ class Project(object):
 
         return response, model_name
 
+    def load_model(self):
+        self._begin_read()
+        status = False
+        model_name = self._dynamic_load_model()
+        logger.debug('Loaidng model %s', model_name)
+
+        self._loader_lock.acquire()
+        try:
+            if not self._models.get(model_name):
+                interpreter = self._interpreter_for_model(model_name)
+                self._models[model_name] = interpreter
+                status = True
+        finally:
+            self._loader_lock.release()
+
+        self._end_read()
+
+        return status
+
     def update(self, model_name):
         self._writer_lock.acquire()
         self._models[model_name] = None

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -368,14 +368,17 @@ if __name__ == '__main__':
     cmdline_args = create_argument_parser().parse_args()
 
     utils.configure_colored_logging(cmdline_args.loglevel)
-    logger.debug(cmdline_args)
+    pre_load = cmdline_args.pre_load
 
     router = DataRouter(cmdline_args.path,
                         cmdline_args.max_training_processes,
                         cmdline_args.response_log,
                         cmdline_args.emulate,
-                        cmdline_args.storage,
-                        pre_load=cmdline_args.pre_load)
+                        cmdline_args.storage)
+    if pre_load:
+        logger.debug('Preloading....')
+        router._pre_load(pre_load)
+
     rasa = RasaNLU(
             router,
             cmdline_args.loglevel,

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -37,7 +37,7 @@ def create_argument_parser():
                         type=int,
                         default=5000,
                         help='port on which to run server')
-    parser.add_argument('-p', '--pre_load',
+    parser.add_argument('--pre_load',
                         nargs='+',
                         default=[],
                         help='Preload models into memory before starting the '

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -38,9 +38,13 @@ def create_argument_parser():
                         default=5000,
                         help='port on which to run server')
     parser.add_argument('-p', '--pre_load',
-                        nargs='*',
+                        nargs='+',
                         default=[],
-                        help='Load all models before starting the server')
+                        help='Preload models into memory before starting the '
+                             'server. \nIf given `all` as input all the models'
+                             ' will be loaded.\nElse you can specify a list of'
+                             ' specific project names.\n Eg: python -m rasa_'
+                             'nlu.server -p project1 project2 --path projects')
     parser.add_argument('-t', '--token',
                         help="auth token. If set, reject requests which don't "
                              "provide this token as a query parameter")

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -377,6 +377,8 @@ if __name__ == '__main__':
                         cmdline_args.storage)
     if pre_load:
         logger.debug('Preloading....')
+        if 'all' in pre_load:
+            pre_load = router.project_store.keys()
         router._pre_load(pre_load)
 
     rasa = RasaNLU(

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -37,11 +37,10 @@ def create_argument_parser():
                         type=int,
                         default=5000,
                         help='port on which to run server')
-    parser.add_argument('-a', '--auto_load',
-                        type=bool,
-                        default=False,
-                        choices=[True, False],
-                        help='Load all models automatically')
+    parser.add_argument('-p', '--pre_load',
+                        nargs='*',
+                        default=[],
+                        help='Load all models before starting the server')
     parser.add_argument('-t', '--token',
                         help="auth token. If set, reject requests which don't "
                              "provide this token as a query parameter")
@@ -365,13 +364,14 @@ if __name__ == '__main__':
     cmdline_args = create_argument_parser().parse_args()
 
     utils.configure_colored_logging(cmdline_args.loglevel)
+    logger.debug(cmdline_args)
 
     router = DataRouter(cmdline_args.path,
                         cmdline_args.max_training_processes,
                         cmdline_args.response_log,
                         cmdline_args.emulate,
                         cmdline_args.storage,
-                        load_all=cmdline_args.auto_load)
+                        pre_load=cmdline_args.pre_load)
     rasa = RasaNLU(
             router,
             cmdline_args.loglevel,

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -31,12 +31,17 @@ def create_argument_parser():
 
     parser.add_argument('-e', '--emulate',
                         choices=['wit', 'luis', 'dialogflow'],
-                        help='which service to emulate (default: None i.e. use '
-                             'simple built in format)')
+                        help='which service to emulate (default: None i.e. use'
+                             ' simple built in format)')
     parser.add_argument('-P', '--port',
                         type=int,
                         default=5000,
                         help='port on which to run server')
+    parser.add_argument('-a', '--auto_load',
+                        type=bool,
+                        default=False,
+                        choices=[True, False],
+                        help='Load all models automatically')
     parser.add_argument('-t', '--token',
                         help="auth token. If set, reject requests which don't "
                              "provide this token as a query parameter")
@@ -365,7 +370,8 @@ if __name__ == '__main__':
                         cmdline_args.max_training_processes,
                         cmdline_args.response_log,
                         cmdline_args.emulate,
-                        cmdline_args.storage)
+                        cmdline_args.storage,
+                        load_all=cmdline_args.auto_load)
     rasa = RasaNLU(
             router,
             cmdline_args.loglevel,


### PR DESCRIPTION
**Proposed changes**: Preload the projects into the memory before starting the server as per user requirement through command line argument. By default, no projects will be loaded. If specified an argument `--pre_load` as `all`, all the projects will be preloaded with the latest model. Otherwise, the user can specify a list of projects and those alone will be preloaded.


**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
