### PR TITLE
Error Logging, Confidence Histogram, Auto-Save

### DIFF
--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -37,12 +37,10 @@ def create_argument_parser():
             description='evaluate a Rasa NLU pipeline with cross '
                         'validation or on external data')
 
-    parser.add_argument('-d', '--data',
-                        required=True,
+    parser.add_argument('-d', '--data', required=True,
                         help="file containing training/evaluation data")
 
-    parser.add_argument('--mode',
-                        default="evaluation",
+    parser.add_argument('--mode', default="evaluation",
                         help="evaluation|crossvalidation (evaluate "
                              "pretrained model or train model "
                              "by crossvalidation)")
@@ -194,7 +192,7 @@ def show_nlu_errors(targets, preds, messages, conf):  # pragma: no cover
             "true_label": targets[i],
             "prediction": preds[i],
             "confidence": conf[i]}
-            for i in range(len(messages)) if not (targets[i] == preds[i])]
+        for i in range(len(messages)) if not (targets[i] == preds[i])]
 
     if errors['nlu']:
         errors = json.dumps(errors, indent=4)
@@ -598,7 +596,7 @@ def run_evaluation(data_path, model_path,
                                                         interpreter, test_data)
         logger.info("Intent evaluation results:")
         evaluate_intents(intent_targets, intent_predictions, messages,
-                            confidences)
+                         confidences)
 
     if extractors:
         entity_targets = get_entity_targets(test_data)
@@ -696,7 +694,7 @@ def compute_intent_metrics(interpreter, corpus):
                                                             interpreter, corpus)
     intent_targets, intent_predictions, messages, confidences = \
         remove_empty_intent_examples(intent_targets, intent_predictions,
-                                        messages, confidences)
+                                     messages, confidences)
 
     # compute fold metrics
     _, precision, f1, accuracy = get_evaluation_metrics(intent_targets,

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 from collections import namedtuple
 
 import numpy as np
+import json
 
 from rasa_nlu import training_data, utils, config
 from rasa_nlu.config import RasaNLUModelConfig
@@ -57,6 +58,20 @@ def create_argument_parser():
     parser.add_argument('-f', '--folds', required=False, default=10,
                         help="number of CV folds (crossvalidation only)")
 
+    parser.add_argument('-e', '--errors', required=False,
+                        default="nlu_errors.json",
+                        help="output path for the json file showing samples"
+                            "with wrong predictions")
+
+    parser.add_argument('--histogram', required=False,
+                        default="confidence_distribution.png",
+                        help="output path for the confidence distribution "
+                        "histogram plot")
+
+    parser.add_argument('-o', '--output', required=False,
+                        default="confusion_matrix.png",
+                        help="output path for the confusion matrix plot")
+
     utils.add_logging_option_arguments(parser, default=logging.INFO)
 
     return parser
@@ -100,6 +115,20 @@ def plot_confusion_matrix(cm, classes,
     plt.ylabel('True label')
     plt.xlabel('Predicted label')
 
+def plot_histogram(hist_data):  # pragma: no cover
+    """Plots a histogram of the confidence distribution of the predictions
+        and saves it to file"""
+    import matplotlib.pyplot as plt
+
+    plt.xlim([0, 1])
+    plt.hist(hist_data, bins=[0.05*i for i in range(1,21)])
+    plt.title('Intent Prediction Confidence Distribution')
+    plt.xlabel('Confidence')
+    plt.ylabel('Number of Samples')
+    fig = plt.gcf()
+    fig.set_size_inches(15, 15)
+    fig.savefig(cmdline_args.histogram, bbox_inches='tight')
+
 
 def log_evaluation_table(targets, predictions):  # pragma: no cover
     """Logs the sklearn evaluation metrics"""
@@ -128,14 +157,16 @@ def get_evaluation_metrics(targets, predictions):  # pragma: no cover
     return report, precision, f1, accuracy
 
 
-def remove_empty_intent_examples(targets, predictions):
+def remove_empty_intent_examples(targets, predictions, messages, confidences):
     """Removes those examples without intent."""
 
     targets = np.array(targets)
     mask = targets != ""
     targets = targets[mask]
     predictions = np.array(predictions)[mask]
-    return targets, predictions
+    messages = np.array(messages)[mask]
+    confidences = np.array(confidences)[mask]
+    return targets, predictions, messages, confidences
 
 
 def clean_intent_labels(labels):
@@ -158,9 +189,30 @@ def drop_intents_below_freq(td, cutoff=5):
     return TrainingData(keep_examples, td.entity_synonyms, td.regex_features)
 
 
-def evaluate_intents(targets, predictions):  # pragma: no cover
-    """Creates a confusion matrix and summary statistics for intent predictions.
+def show_nlu_errors(targets, predictions, messages, confidences):  # pragma: no cover
+    """Logs messages which result in wrong predictions and saves them to file"""
+    
+    errors = {}
+    errors['nlu'] = [{"text": messages[i],
+                "true_label": targets[i],
+                "prediction": predictions[i],
+                "confidence": confidences[i]} for i in range(len(messages)) if not (targets[i] == predictions[i])]
+    if errors['nlu']:
+        errors = json.dumps(errors, indent=4)
+        logger.info("\n\nThese intent examples could not be classified correctly \n{}".format(errors))
+        with open(cmdline_args.errors, 'w') as error_file:
+            error_file.write(errors)
+        logger.info("Errors were saved to file {}.".format(cmdline_args.errors))
+    else:
+        logger.info("No prediction errors were found. You are AWESOME!")
 
+
+def evaluate_intents(targets, predictions, messages, confidences):  # pragma: no cover
+    """Creates a confusion matrix and summary statistics for intent predictions.
+    Logs samples which could not be classified correctly and saves them to file
+    (nlu_errors.json as default).
+    Creates a confidence histogram which is saved to file
+    (confidence_distribution.png as default).
     Only considers those examples with a set intent.
     Others are filtered out."""
     from sklearn.metrics import confusion_matrix
@@ -169,20 +221,32 @@ def evaluate_intents(targets, predictions):  # pragma: no cover
 
     # remove empty intent targets
     num_examples = len(targets)
-    targets, predictions = remove_empty_intent_examples(targets, predictions)
+    targets, predictions, messages, confidences = remove_empty_intent_examples(targets, predictions, messages, confidences)
     logger.info("Intent Evaluation: Only considering those "
                 "{} examples that have a defined intent out "
                 "of {} examples".format(targets.size, num_examples))
     log_evaluation_table(targets, predictions)
+
+    # log and save misclassified samples to file for debugging
+    show_nlu_errors(targets, predictions, messages, confidences)
+
+    # create histogram of confidence distribution, save to file and display
+    hist = [confidences[i] for i in range(len(messages)) if (targets[i] == predictions[i])]
+    plot_histogram(hist)
+    plt.show()
+    plt.gcf().clear()
 
     cnf_matrix = confusion_matrix(targets, predictions)
     labels = unique_labels(targets, predictions)
     plot_confusion_matrix(cnf_matrix,
                           classes=labels,
                           title='Intent Confusion matrix')
+    # save confusion matrix to file before showing it
+    fig = plt.gcf()
+    fig.set_size_inches(15, 15)
+    fig.savefig(cmdline_args.output, bbox_inches='tight')
 
     plt.show()
-
 
 def merge_labels(aligned_predictions, extractor=None):
     """Concatenates all labels of the aligned predictions.
@@ -401,13 +465,29 @@ def extract_entities(result):  # pragma: no cover
     return result.get('entities', [])
 
 
+def extract_message(result):  # pragma: no cover
+    """Extracts the original message from a parsing result."""
+    return result.get('text', {})
+
+
+def extract_confidence(result):  # pragma: no cover
+    """Extracts the confidence from a parsing result."""
+    return result.get('intent', {}).get('confidence')
+
+
 def get_intent_predictions(interpreter, test_data):  # pragma: no cover
-    """Runs the model for the test set and extracts intent predictions"""
+    """Runs the model for the test set and extracts intent predictions.
+        Returns intent predictions, the original messages
+        and the confidences of the predictions"""
     intent_predictions = []
+    messages = []
+    confidences = []
     for e in test_data.training_examples:
         res = interpreter.parse(e.text, only_output_properties=False)
         intent_predictions.append(extract_intent(res))
-    return intent_predictions
+        messages.append(extract_message(res))
+        confidences.append(extract_confidence(res))
+    return intent_predictions, messages, confidences
 
 
 def get_entity_predictions(interpreter, test_data):  # pragma: no cover
@@ -512,9 +592,9 @@ def run_evaluation(data_path, model_path,
 
     if is_intent_classifier_present(interpreter):
         intent_targets = get_intent_targets(test_data)
-        intent_predictions = get_intent_predictions(interpreter, test_data)
+        intent_predictions, messages, confidences = get_intent_predictions(interpreter, test_data)
         logger.info("Intent evaluation results:")
-        evaluate_intents(intent_targets, intent_predictions)
+        evaluate_intents(intent_targets, intent_predictions, messages, confidences)
 
     if extractors:
         entity_targets = get_entity_targets(test_data)
@@ -608,9 +688,9 @@ def compute_intent_metrics(interpreter, corpus):
     if not is_intent_classifier_present(interpreter):
         return {}
     intent_targets = get_intent_targets(corpus)
-    intent_predictions = get_intent_predictions(interpreter, corpus)
-    intent_targets, intent_predictions = remove_empty_intent_examples(
-            intent_targets, intent_predictions)
+    intent_predictions, messages, confidences = get_intent_predictions(interpreter, corpus)
+    intent_targets, intent_predictions, messages, confidences = remove_empty_intent_examples(
+            intent_targets, intent_predictions, messages, confidences)
 
     # compute fold metrics
     _, precision, f1, accuracy = get_evaluation_metrics(intent_targets,

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import io
 import itertools
 import logging
 import shutil
@@ -198,7 +199,7 @@ def show_nlu_errors(targets, preds, messages, conf):  # pragma: no cover
         errors = json.dumps(errors, indent=4)
         logger.info("\n\nThese intent examples could not be classified "
                     "correctly \n{}".format(errors))
-        with open(cmdline_args.errors, 'w') as error_file:
+        with io.open(cmdline_args.errors, 'w') as error_file:
             error_file.write(errors)
         logger.info("Errors were saved to file {}.".format(cmdline_args.errors))
     else:

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -37,16 +37,19 @@ def create_argument_parser():
             description='evaluate a Rasa NLU pipeline with cross '
                         'validation or on external data')
 
-    parser.add_argument('-d', '--data', required=True,
+    parser.add_argument('-d', '--data',
+                        required=True,
                         help="file containing training/evaluation data")
 
-    parser.add_argument('--mode', default="evaluation",
+    parser.add_argument('--mode',
+                        default="evaluation",
                         help="evaluation|crossvalidation (evaluate "
                              "pretrained model or train model "
                              "by crossvalidation)")
 
     # todo: make the two different modes two subparsers
     parser.add_argument('-c', '--config',
+
                         help="model configurion file (crossvalidation only)")
 
     parser.add_argument('-m', '--model', required=False,
@@ -55,13 +58,13 @@ def create_argument_parser():
     parser.add_argument('-f', '--folds', required=False, default=10,
                         help="number of CV folds (crossvalidation only)")
 
-    parser.add_argument('-e', '--errors', required=False, default="errors.json",
+    parser.add_argument('--errors', required=False, default="errors.json",
                         help="output path for the json with wrong predictions")
 
     parser.add_argument('--histogram', required=False, default="hist.png",
                         help="output path for the confidence histogram")
 
-    parser.add_argument('-o', '--output', required=False, default="confmat.png",
+    parser.add_argument('--confmat', required=False, default="confmat.png",
                         help="output path for the confusion matrix plot")
 
     utils.add_logging_option_arguments(parser, default=logging.INFO)
@@ -188,10 +191,10 @@ def show_nlu_errors(targets, preds, messages, conf):  # pragma: no cover
     errors = {}
     errors['nlu'] = [
         {"text": messages[i],
-        "true_label": targets[i],
-        "prediction": preds[i],
-        "confidence": conf[i]} \
-        for i in range(len(messages)) if not (targets[i] == preds[i])]
+            "true_label": targets[i],
+            "prediction": preds[i],
+            "confidence": conf[i]}
+            for i in range(len(messages)) if not (targets[i] == preds[i])]
 
     if errors['nlu']:
         errors = json.dumps(errors, indent=4)
@@ -206,7 +209,7 @@ def show_nlu_errors(targets, preds, messages, conf):  # pragma: no cover
 
 def evaluate_intents(targets, preds, messages, conf):  # pragma: no cover
     """Creates a confusion matrix and summary statistics for intent predictions.
-    Logs samples which could not be classified correctly and saves them to file.
+    Log samples which could not be classified correctly and save them to file.
     Creates a confidence histogram which is saved to file.
     Only considers those examples with a set intent.
     Others are filtered out."""
@@ -229,8 +232,7 @@ def evaluate_intents(targets, preds, messages, conf):  # pragma: no cover
     show_nlu_errors(targets, preds, messages, conf)
 
     # create histogram of confidence distribution, save to file and display
-    hist = [conf[i] for i in range(len(messages)) \
-                            if (targets[i] == preds[i])]
+    hist = [conf[i] for i in range(len(messages)) if (targets[i] == preds[i])]
 
     plot_histogram(hist)
     plt.show()
@@ -238,13 +240,12 @@ def evaluate_intents(targets, preds, messages, conf):  # pragma: no cover
 
     cnf_matrix = confusion_matrix(targets, preds)
     labels = unique_labels(targets, preds)
-    plot_confusion_matrix(cnf_matrix,
-                          classes=labels,
+    plot_confusion_matrix(cnf_matrix, classes=labels,
                           title='Intent Confusion matrix')
     # save confusion matrix to file before showing it
     fig = plt.gcf()
     fig.set_size_inches(15, 15)
-    fig.savefig(cmdline_args.output, bbox_inches='tight')
+    fig.savefig(cmdline_args.confmat, bbox_inches='tight')
 
     plt.show()
 
@@ -597,7 +598,7 @@ def run_evaluation(data_path, model_path,
                                                         interpreter, test_data)
         logger.info("Intent evaluation results:")
         evaluate_intents(intent_targets, intent_predictions, messages,
-                        confidences)
+                            confidences)
 
     if extractors:
         entity_targets = get_entity_targets(test_data)
@@ -695,7 +696,7 @@ def compute_intent_metrics(interpreter, corpus):
                                                             interpreter, corpus)
     intent_targets, intent_predictions, messages, confidences = \
         remove_empty_intent_examples(intent_targets, intent_predictions,
-                                    messages, confidences)
+                                        messages, confidences)
 
     # compute fold metrics
     _, precision, f1, accuracy = get_evaluation_metrics(intent_targets,

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -115,7 +115,7 @@ def plot_histogram(hist_data):  # pragma: no cover
     import matplotlib.pyplot as plt
 
     plt.xlim([0, 1])
-    plt.hist(hist_data, bins=[0.05*i for i in range(1, 21)])
+    plt.hist(hist_data, bins=[0.05 * i for i in range(1, 21)])
     plt.title('Intent Prediction Confidence Distribution')
     plt.xlabel('Confidence')
     plt.ylabel('Number of Samples')

--- a/tests/base/test_evaluation.py
+++ b/tests/base/test_evaluation.py
@@ -243,11 +243,16 @@ def test_run_cv_evaluation():
 def test_empty_intent_removal():
     targets = ["", "greet"]
     predicted = ["restaurant_search", "greet"]
+    messages = ["I am hungry", "hello"]
+    conf = ["0.12345", "0.98765"]
 
-    targets_r, predicted_r = remove_empty_intent_examples(targets, predicted)
+    targets_r, predicted_r, messages_r, conf_r = remove_empty_intent_examples(
+                                            targets, predicted, messages, conf)
 
     assert targets_r == ["greet"]
     assert predicted_r == ["greet"]
+    assert messages_r == ["hello"]
+    assert conf_r == ["0.98765"]
 
 
 def test_evaluate_entities():


### PR DESCRIPTION
As discussed with @amn41 :
- added logging of samples which are not classified correctly to make
debugging easier (shows in log and saved to file)
- added a histogram of confidence level of predictions to choose
threshold for „I did not understand that question“ and as indication of
model robustness
- added auto-saving of confusion matrix plot to file

**Status (please check what you already did):**
- [x] made PR ready for code review
- [ ] added some tests for the functionality 
- [ ] updated the documentation
- [ ] updated the changelog