### PR TITLE
Added remote_storage to train process. 

### DIFF
--- a/rasa_nlu/data_router.py
+++ b/rasa_nlu/data_router.py
@@ -320,7 +320,8 @@ class DataRouter(object):
                                   train_config,
                                   data_file,
                                   path=self.project_dir,
-                                  project=project)
+                                  project=project,
+                                  storage=self.remote_storage)
         result = deferred_from_future(result)
         result.addCallback(training_callback)
         result.addErrback(training_errback)


### PR DESCRIPTION

**Proposed changes**:
- This used to work in the previous versions of rasa. Latest master didn't have a remote_storage connection to the training process. So, models doesn't get uploaded. This will push the model to Remote storage after training. Is that intentionally left out or a bug?

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [n/a ] added some tests for the functionality
- [/a] updated the documentation
- [n/a] updated the changelog
