### PR TITLE
lowercase text in count vector featurizer

### DIFF
--- a/rasa_nlu/featurizers/count_vectors_featurizer.py
+++ b/rasa_nlu/featurizers/count_vectors_featurizer.py
@@ -102,7 +102,7 @@ class CountVectorsFeaturizer(Featurizer):
         self.vect = None
 
         # preprocessor
-        self.preprocessor = lambda s: re.sub(r'\b[0-9]+\b', 'NUMBER', s)
+        self.preprocessor = lambda s: re.sub(r'\b[0-9]+\b', 'NUMBER', s.lower())
 
     @classmethod
     def required_packages(cls):


### PR DESCRIPTION
**Proposed changes**:
- Lowercase text before passing to count vector featurizer. I think wanting to threat capitalised & uncapitalised words differently is such a rare use case that we don't even need to make this confugrable. thoughts?

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
