### PR TITLE
LUIS emulator output: entity - start, end positions and confidence scores are added

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Removed
 
 Fixed
 -----
+- Fixed Luis emulation output to add start, end position and confidence for each entity.
 
 
 [0.12.3] - 2018-05-02

--- a/rasa_nlu/emulators/luis.py
+++ b/rasa_nlu/emulators/luis.py
@@ -47,9 +47,9 @@ class LUISEmulator(NoEmulator):
                 {
                     "entity": e["value"],
                     "type": e["entity"],
-                    "startIndex": None,
-                    "endIndex": None,
-                    "score": None
+                    "startIndex": e["start"],
+                    "endIndex": e["end"]-1,
+                    "score": e["confidence"]
                 } for e in data["entities"]
             ] if "entities" in data else []
         }


### PR DESCRIPTION
**Proposed changes**:
- LUIS emulator output: entity - start, end positions and confidence scores are added

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
