### PR TITLE
Allow to run evaluate script from other code via main function.

### DIFF
--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -680,7 +680,7 @@ def return_entity_results(results, dataset_name):
             return_results(result, dataset_name)
 
 
-if __name__ == '__main__':  # pragma: no cover
+def main():
     parser = create_argument_parser()
     cmdline_args = parser.parse_args()
 
@@ -718,3 +718,7 @@ if __name__ == '__main__':  # pragma: no cover
         run_evaluation(cmdline_args.data, cmdline_args.model)
 
     logger.info("Finished evaluation")
+
+
+if __name__ == '__main__':  # pragma: no cover
+    main()


### PR DESCRIPTION
**Proposed changes**:
- This refactores the evaluate script, so that the script can be called via the main function from somewhere else.
- Use case: We want to set different numpy printoptions before running the script.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
