### PR TITLE
Train with json config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ This project adheres to `Semantic Versioning`_ starting with version 0.7.0.
 
 Added
 -----
+- allow pure json including pipeline configuration on train endpoint
 - doc link to a community contribution for Rasa NLU in Chinese
 - support for component ``count_vectors_featurizer`` use ``tokens`` feature provide by tokenizer
 - 2-character and a 5-character prefix features to ``ner_crf``

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -308,7 +308,8 @@ class RasaNLU(object):
 
         else:
 
-            raise Exception("Content-Type must be 'application/x-yml' or 'application/json'")
+            raise Exception("Content-Type must be 'application/x-yml' "
+                            "or 'application/json'")
 
         return model_config, data
 

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -209,7 +209,6 @@ class RasaNLU(object):
     @app.route("/", methods=['GET', 'OPTIONS'])
     @check_cors
     def hello(self, request):
-        print("Hitting the test page")
         """Main Rasa route to check if the server is online"""
         return "hello from Rasa NLU: " + __version__
 
@@ -283,8 +282,6 @@ class RasaNLU(object):
     @check_cors
     @inlineCallbacks
     def train(self, request):
-
-        print("inside train")
         # if not set will use the default project name, e.g. "default"
         project = parameter_or_default(request, "project", default=None)
         # if set will not generate a model name but use the passed one
@@ -296,88 +293,38 @@ class RasaNLU(object):
             # assumes the user submitted a model configuration with a data
             # parameter attached to it
 
-            print("inside yaml model config")
-
             model_config = utils.read_yaml(request_content)
             data = model_config.get("data")
 
-            # inspecting the format of the dicts from yaml
-            print(simplejson.dumps(model_config,indent=4))
-            print(simplejson.dumps(data, indent=4))
-
-            print("==================")
-
-            print(type(model_config))
-            print(type(data))
-
-            print("==================")
-
         else:
-            # assumes the caller just provided training data without config
+            # If the caller just provided training data without config
             # this will use the default model config the server
             # was started with
-
-            # If we handle the config inside json, it invalidates the above assumption.
-            # We will have to test the structure of the json to see if it is just data
-            # or if it contains the config as well. I will mimic the structure from the
-            # x-yml format.
-
-            print("inside else")
 
             # test if json has config structure
             json_config = simplejson.loads(request_content).get("data")
 
-            # if it does then this results in correct formt.
+            # if it does then this results in correct format.
             if json_config:
-
-                print("inside json model config")
 
                 model_config = simplejson.loads(request_content)
                 data = json_config
 
-                # inspecting the format of the dicts from json + config
-                print(simplejson.dumps(model_config, indent=4))
-                print(simplejson.dumps(data, indent=4))
-
-                print("==================")
-
-                print(type(model_config))
-                print(type(data))
-
-                print("==================")
-
             # otherwise use defaults.
             else:
-                print("inside default config just data")
+
                 model_config = self.default_model_config
                 data = request_content
 
-                # inspecting the format of the dicts from json + config
-                print(simplejson.dumps(model_config, indent=4))
-                print(simplejson.dumps(data, indent=4))
-
-                print("==================")
-
-                print(type(model_config))
-                print(type(data))
-
-                print("==================")
-
-
-
         data_file = dump_to_data_file(data)
-
-        print(data_file)
 
         request.setHeader('Content-Type', 'application/json')
 
         try:
             request.setResponseCode(200)
-            print("before start train process")
             response = yield self.data_router.start_train_process(
                     data_file, project,
                     RasaNLUModelConfig(model_config), model_name)
-            print("before return value")
             returnValue(json_to_string({'info': 'new model trained: {}'
                                                 ''.format(response)}))
         except AlreadyTrainingError as e:
@@ -389,9 +336,6 @@ class RasaNLU(object):
         except TrainingException as e:
             request.setResponseCode(500)
             returnValue(json_to_string({"error": "{}".format(e)}))
-
-        print("done with train")
-
 
     @app.route("/evaluate", methods=['POST', 'OPTIONS'])
     @requires_auth

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -166,6 +166,7 @@ def is_yaml_request(request):
     return "yml" in next(
             iter(request.requestHeaders.getRawHeaders("Content-Type", [])), "")
 
+
 def is_json_request(request):
     return "json" in next(
             iter(request.requestHeaders.getRawHeaders("Content-Type", [])), "")
@@ -303,8 +304,6 @@ class RasaNLU(object):
 
         request_content = request.content.read().decode('utf-8', 'strict')
 
-
-
         if is_yaml_request(request):
             # assumes the user submitted a model configuration with a data
             # parameter attached to it
@@ -412,7 +411,7 @@ class RasaNLU(object):
 
 if __name__ == '__main__':
     # Running as standalone python application
-    cmdline_args = create_argument_parser().parse_args(['--path', '/Users/coryhurst/Documents/Git_Stuff/Samtecspg2/local-storage'])
+    cmdline_args = create_argument_parser().parse_args()
 
     utils.configure_colored_logging(cmdline_args.loglevel)
     pre_load = cmdline_args.pre_load

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -322,9 +322,11 @@ class RasaNLU(object):
 
         try:
             request.setResponseCode(200)
+
             response = yield self.data_router.start_train_process(
                     data_file, project,
                     RasaNLUModelConfig(model_config), model_name)
+
             returnValue(json_to_string({'info': 'new model trained: {}'
                                                 ''.format(response)}))
         except AlreadyTrainingError as e:

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -161,10 +161,6 @@ def dump_to_data_file(data):
 
     return utils.create_temporary_file(data_string, "_training_data")
 
-
-
-
-
 class RasaNLU(object):
     """Class representing Rasa NLU http server"""
 
@@ -321,7 +317,7 @@ class RasaNLU(object):
     def get_request_content_type(self, request):
         content_type = request.requestHeaders.getRawHeaders("Content-Type", [])
 
-        if len(content_type>1):
+        if len(content_type > 1):
             raise Exception("Only one content type is valid")
         else:
             return content_type

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -303,23 +303,20 @@ class RasaNLU(object):
             data = model_config.get("data")
 
         elif 'json' in content_type:
-            # If the caller just provided training data without config
-            # this will use the default model config the server
-            # was started with
 
             model_config, data = self.extract_json(request_content)
 
         else:
 
-            raise Exception("Content-Type must be yml or json")
+            raise Exception("Content-Type must be 'application/x-yml' or 'application/json'")
 
         return model_config, data
 
     def get_request_content_type(self, request):
         content_type = request.requestHeaders.getRawHeaders("Content-Type", [])
 
-        if len(content_type) > 1:
-            raise Exception("Only one content type is valid")
+        if len(content_type) is not 1:
+            raise Exception("The request must have exactly one content type")
         else:
             return content_type[0]
 

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -161,6 +161,7 @@ def dump_to_data_file(data):
 
     return utils.create_temporary_file(data_string, "_training_data")
 
+
 class RasaNLU(object):
     """Class representing Rasa NLU http server"""
 
@@ -317,10 +318,10 @@ class RasaNLU(object):
     def get_request_content_type(self, request):
         content_type = request.requestHeaders.getRawHeaders("Content-Type", [])
 
-        if len(content_type > 1):
+        if len(content_type) > 1:
             raise Exception("Only one content type is valid")
         else:
-            return content_type
+            return content_type[0]
 
     @app.route("/train", methods=['POST', 'OPTIONS'])
     @requires_auth

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -281,9 +281,29 @@ class RasaNLU(object):
         request.setHeader('Content-Type', 'application/json')
         return json_to_string(self.data_router.get_status())
 
+    def extract_json(self, content):
+        # test if json has config structure
+        json_config = simplejson.loads(content).get("data")
+
+        # if it does then this results in correct format.
+        if json_config:
+
+            model_config = simplejson.loads(content)
+            data = json_config
+
+        # otherwise use defaults.
+        else:
+
+            model_config = self.default_model_config
+            data = content
+
+        return model_config, data
+
     def extract_data_and_config(self, request):
 
         request_content = request.content.read().decode('utf-8', 'strict')
+
+
 
         if is_yaml_request(request):
             # assumes the user submitted a model configuration with a data
@@ -297,21 +317,10 @@ class RasaNLU(object):
             # this will use the default model config the server
             # was started with
 
-            # test if json has config structure
-            json_config = simplejson.loads(request_content).get("data")
+            model_config, data = self.extract_json(request_content)
 
-            # if it does then this results in correct format.
-            if json_config:
-
-                model_config = simplejson.loads(request_content)
-                data = json_config
-
-            # otherwise use defaults.
-            else:
-
-                model_config = self.default_model_config
-                data = request_content
         else:
+
             raise Exception("Content-Type must be yml or json")
 
         return model_config, data

--- a/tests/base/test_server.py
+++ b/tests/base/test_server.py
@@ -183,6 +183,15 @@ def test_model_hot_reloading(app, rasa_default_train_data):
     app.flush()
     response = yield response
     assert response.code == 200, "Training should end successfully"
+
+    response = app.post(train_u,
+                        headers={b"Content-Type": b"application/json"},
+                        data=json.dumps(model_config))
+    time.sleep(3)
+    app.flush()
+    response = yield response
+    assert response.code == 200, "Training should end successfully"
+
     response = yield app.get(query)
     assert response.code == 200, "Project should now exist after it got trained"
 


### PR DESCRIPTION
**Proposed changes**:
- ...
added ability to accept pure json that includes both pipeline configuration and rasa data in the /train endpoint of the http server. 

**Status (please check what you already did)**:
- [x ] made PR ready for code review
- [x ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
