### PR TITLE
Fixes issue #51

### DIFF
--- a/rasa_nlu/utils/__init__.py
+++ b/rasa_nlu/utils/__init__.py
@@ -335,9 +335,8 @@ def create_temporary_file(data, suffix=""):
     """Creates a tempfile.NamedTemporaryFile object for data"""
 
     if PY3:
-        f = tempfile.NamedTemporaryFile("w+", suffix=suffix,
-                                        delete=False,
-                                        encoding="utf-8")
+        f = tempfile.NamedTemporaryFile("w+b", suffix=suffix,
+                                        delete=False)
         f.write(data)
     else:
         f = tempfile.NamedTemporaryFile("w+", suffix=suffix,


### PR DESCRIPTION
`rasa_nlu` was throwing errors when trying to load training data via url.  This was due to a byte encoding error.  Fixes issue 
https://github.com/RasaHQ/rasa_platform/issues/51

**Proposed changes**:
- changes 
`f = tempfile.NamedTemporaryFile("w+", suffix=suffix, delete=False, encoding="utf-8")`
to
`f = tempfile.NamedTemporaryFile("w+b", suffix=suffix, delete=False)`
for python 3

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
