### PR TITLE
Url fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,7 +46,7 @@ Removed
 Fixed
 -----
 - Fixed Luis emulation output to add start, end position and confidence for each entity.
-
+- Fixed byte encoding issue where training data could not be loaded by URL in python 3.
 
 [0.12.3] - 2018-05-02
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/rasa_nlu/training_data/loading.py
+++ b/rasa_nlu/training_data/loading.py
@@ -70,7 +70,8 @@ def load_data_from_url(url, language='en'):
     try:
         response = requests.get(url)
         response.raise_for_status()
-        temp_data_file = utils.create_temporary_file(response.content)
+        temp_data_file = utils.create_temporary_file(response.content,
+                                                     mode="w+b")
         return _load(temp_data_file, language)
     except Exception as e:
         logger.warning("Could not retrieve training data "

--- a/rasa_nlu/utils/__init__.py
+++ b/rasa_nlu/utils/__init__.py
@@ -331,11 +331,13 @@ def pycloud_pickle(file_name, obj):
         cloudpickle.dump(obj, f)
 
 
-def create_temporary_file(data, suffix=""):
-    """Creates a tempfile.NamedTemporaryFile object for data"""
+def create_temporary_file(data, suffix="", mode="w+"):
+    """Creates a tempfile.NamedTemporaryFile object for data.
+
+    mode defines NamedTemporaryFile's  mode parameter in py3."""
 
     if PY3:
-        f = tempfile.NamedTemporaryFile("w+b", suffix=suffix,
+        f = tempfile.NamedTemporaryFile(mode=mode, suffix=suffix,
                                         delete=False)
         f.write(data)
     else:

--- a/rasa_nlu/utils/__init__.py
+++ b/rasa_nlu/utils/__init__.py
@@ -335,9 +335,8 @@ def create_temporary_file(data, suffix=""):
     """Creates a tempfile.NamedTemporaryFile object for data"""
 
     if PY3:
-        f = tempfile.NamedTemporaryFile("w+", suffix=suffix,
-                                        delete=False,
-                                        encoding="utf-8")
+        f = tempfile.NamedTemporaryFile("w+b", suffix=suffix,
+                                        delete=False)
         f.write(data)
     else:
         f = tempfile.NamedTemporaryFile("w+", suffix=suffix,

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -6,6 +6,8 @@ from __future__ import unicode_literals
 
 import tempfile
 
+import requests
+
 import pytest
 from jsonschema import ValidationError
 
@@ -332,3 +334,10 @@ def test_training_data_conversion(tmpdir, data_file, gold_standard_file,
     # to dump to the file and diff using git
     # with io.open(gold_standard_file) as f:
     #     f.write(td.as_json(indent=2))
+
+
+def test_url_data_format():
+    test_url = 'http://website-demo.rasa.com/api/default/data.json?api_token=e8c436157a24b007ed5cdc9ba4d062ed66c4f63d'
+    r = requests.get(test_url)
+    data = r.json()
+    validate_rasa_nlu_data(data)

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -372,6 +372,8 @@ def test_url_data_format():
         ]
       }
     }"""
-    fname = utils.create_temporary_file(data.encode("utf-8"), suffix="_tmp_training_data.json")
+    fname = utils.create_temporary_file(data.encode("utf-8"),
+                                        suffix="_tmp_training_data.json",
+                                        mode="w+b")
     data = utils.read_json_file(fname)
     validate_rasa_nlu_data(data)

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -375,4 +375,3 @@ def test_url_data_format():
     fname = utils.create_temporary_file(data.encode("utf-8"), suffix="_tmp_training_data.json")
     data = utils.read_json_file(fname)
     validate_rasa_nlu_data(data)
-    

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -377,3 +377,4 @@ def test_url_data_format():
                                         mode="w+b")
     data = utils.read_json_file(fname)
     validate_rasa_nlu_data(data)
+    assert data is not None

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -6,8 +6,6 @@ from __future__ import unicode_literals
 
 import tempfile
 
-import requests
-
 import pytest
 from jsonschema import ValidationError
 
@@ -337,7 +335,43 @@ def test_training_data_conversion(tmpdir, data_file, gold_standard_file,
 
 
 def test_url_data_format():
-    test_url = 'http://website-demo.rasa.com/api/default/data.json?api_token=e8c436157a24b007ed5cdc9ba4d062ed66c4f63d'
-    r = requests.get(test_url)
-    data = r.json()
+    data = u"""
+    {
+      "rasa_nlu_data": {
+        "entity_synonyms": [
+          {
+            "value": "nyc",
+            "synonyms": ["New York City", "nyc", "the big apple"]
+          }
+        ],
+        "common_examples" : [
+          {
+            "text": "show me flights to New York City",
+            "intent": "unk",
+            "entities": [
+              {
+                "entity": "destination",
+                "start": 19,
+                "end": 32,
+                "value": "NYC"
+              }
+            ]
+          },
+          {
+            "text": "show me flights to nyc",
+            "intent": "unk",
+            "entities": [
+              {
+                "entity": "destination",
+                "start": 19,
+                "end": 22,
+                "value": "nyc"
+              }
+            ]
+          }
+        ]
+      }
+    }"""
+    fname = utils.create_temporary_file(data.encode("utf-8"), suffix="_tmp_training_data.json")
+    data = utils.read_json_file(fname)
     validate_rasa_nlu_data(data)

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -375,3 +375,4 @@ def test_url_data_format():
     fname = utils.create_temporary_file(data.encode("utf-8"), suffix="_tmp_training_data.json")
     data = utils.read_json_file(fname)
     validate_rasa_nlu_data(data)
+    

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -356,18 +356,6 @@ def test_url_data_format():
                 "value": "NYC"
               }
             ]
-          },
-          {
-            "text": "show me flights to nyc",
-            "intent": "unk",
-            "entities": [
-              {
-                "entity": "destination",
-                "start": 19,
-                "end": 22,
-                "value": "nyc"
-              }
-            ]
           }
         ]
       }
@@ -376,5 +364,5 @@ def test_url_data_format():
                                         suffix="_tmp_training_data.json",
                                         mode="w+b")
     data = utils.read_json_file(fname)
-    validate_rasa_nlu_data(data)
     assert data is not None
+    validate_rasa_nlu_data(data)


### PR DESCRIPTION
rasa_nlu was throwing errors when trying to load training data via url. This was due to a byte encoding error. Fixes issue
RasaHQ/rasa_platform#51

**Proposed changes**:

    changes
    f = tempfile.NamedTemporaryFile("w+", suffix=suffix, delete=False, encoding="utf-8")
    to
    f = tempfile.NamedTemporaryFile("w+b", suffix=suffix, delete=False)
    for python 3


**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
