### PR TITLE
Add missing "requires" to spacy tokenizer

### DIFF
--- a/rasa_nlu/tokenizers/spacy_tokenizer.py
+++ b/rasa_nlu/tokenizers/spacy_tokenizer.py
@@ -21,6 +21,8 @@ class SpacyTokenizer(Tokenizer, Component):
 
     provides = ["tokens"]
 
+    requires = ["spacy_doc"]
+
     def train(self, training_data, config, **kwargs):
         # type: (TrainingData, RasaNLUModelConfig, **Any) -> None
 


### PR DESCRIPTION
**Proposed changes**:
- `SpacyTokenizer` component is missing `requires = ["spacy_doc"]` requirement which is used for validating pipeline correctness on pipeline initialization.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
