### PR TITLE
log wrong intent predictions during evaluation / show histogram of confidence scores

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,8 @@ Added
 - add a feature for each regex in the training set for crf_entity_extractor
 - Current training processes count for server and projects.
 - the ``/version`` endpoint returns a new field ``minimum_compatible_version``
+- added logging of intent prediction errors to evaluation script
+- added histogram of confidence scores to evaluation script
 
 Changed
 -------
@@ -40,6 +42,7 @@ Changed
 - Allow multiple training processes per project
 - Changed AlreadyTrainingError to MaxTrainingError. The first one was used to indicate that the project was already training. The latest will show an error when the server isn't able to training more models.
 - ``Interpreter.ensure_model_compatibility`` takes a new parameters for the version to compare the model version against
+- confusion matrix plot gets saved to file automatically during evaluation
 
 Removed
 -------

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -83,6 +83,9 @@ The evaluation script will log precision, recall, and f1 measure for
 each intent and once summarized for all.
 Furthermore, it creates a confusion matrix for you to see which
 intents are mistaken for which others.
+Samples which have not been predicted correctly are logged and saved to errors.json for easier debugging. 
+Finally, the evaluations script creates a histogram of the confidence distribution for all predictions. 
+Improving the quality of your training data will move the histogram bars to the right.
 
 
 Entity Extraction

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -83,8 +83,9 @@ The evaluation script will log precision, recall, and f1 measure for
 each intent and once summarized for all.
 Furthermore, it creates a confusion matrix for you to see which
 intents are mistaken for which others.
-Samples which have not been predicted correctly are logged and saved to errors.json for easier debugging. 
-Finally, the evaluations script creates a histogram of the confidence distribution for all predictions. 
+Samples which have not been predicted correctly are logged and saved to a file 
+called ``errors.json`` for easier debugging. 
+Finally, the evaluation script creates a histogram of the confidence distribution for all predictions. 
 Improving the quality of your training data will move the histogram bars to the right.
 
 

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -38,19 +38,16 @@ def create_argument_parser():
             description='evaluate a Rasa NLU pipeline with cross '
                         'validation or on external data')
 
-    parser.add_argument('-d', '--data',
-                        required=True,
+    parser.add_argument('-d', '--data', required=True,
                         help="file containing training/evaluation data")
 
-    parser.add_argument('--mode',
-                        default="evaluation",
+    parser.add_argument('--mode', default="evaluation",
                         help="evaluation|crossvalidation (evaluate "
                              "pretrained model or train model "
                              "by crossvalidation)")
 
     # todo: make the two different modes two subparsers
     parser.add_argument('-c', '--config',
-
                         help="model configurion file (crossvalidation only)")
 
     parser.add_argument('-m', '--model', required=False,
@@ -195,7 +192,8 @@ def show_nlu_errors(targets, preds, messages, conf):  # pragma: no cover
     """Log messages which result in wrong predictions and save them to file"""
 
     errors = {}
-    # it could also be interesting to include entity-errors later, therefore we start with a "intent_errors" key
+    # it could be interesting to include entity-errors later
+    # therefore we start with a "intent_errors" key
     errors['intent_errors'] = [
         {"text": messages[i],
             "true_label": targets[i],

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -123,7 +123,7 @@ def plot_histogram(hist_data):  # pragma: no cover
     plt.xlabel('Confidence')
     plt.ylabel('Number of Samples')
     fig = plt.gcf()
-    fig.set_size_inches(15, 15)
+    fig.set_size_inches(10, 10)
     fig.savefig(cmdline_args.histogram, bbox_inches='tight')
 
 
@@ -154,7 +154,7 @@ def get_evaluation_metrics(targets, predictions):  # pragma: no cover
     return report, precision, f1, accuracy
 
 
-def remove_empty_intent_examples(targets, predictions):
+def remove_empty_intent_examples(targets, predictions, messages, confidences):
     """Removes those examples without intent."""
 
     targets = np.array(targets)
@@ -195,14 +195,15 @@ def show_nlu_errors(targets, preds, messages, conf):  # pragma: no cover
     """Log messages which result in wrong predictions and save them to file"""
 
     errors = {}
-    errors['nlu'] = [
+    # it could also be interesting to include entity-errors later, therefore we start with a "intent_errors" key
+    errors['intent_errors'] = [
         {"text": messages[i],
             "true_label": targets[i],
             "prediction": preds[i],
             "confidence": conf[i]}
         for i in range(len(messages)) if not (targets[i] == preds[i])]
 
-    if errors['nlu']:
+    if errors['intent_errors']:
         errors = json.dumps(errors, indent=4)
         logger.info("\n\nThese intent examples could not be classified "
                     "correctly \n{}".format(errors))
@@ -242,7 +243,7 @@ def evaluate_intents(targets, preds, messages, conf):  # pragma: no cover
                           title='Intent Confusion matrix')
     # save confusion matrix to file before showing it
     fig = plt.gcf()
-    fig.set_size_inches(15, 15)
+    fig.set_size_inches(10, 10)
     fig.savefig(cmdline_args.confmat, bbox_inches='tight')
 
     plt.show()
@@ -772,8 +773,6 @@ def return_entity_results(results, dataset_name):
 
 
 def main():
-    parser = create_argument_parser()
-    cmdline_args = parser.parse_args()
 
     utils.configure_colored_logging(cmdline_args.loglevel)
 
@@ -812,4 +811,6 @@ def main():
 
 
 if __name__ == '__main__':  # pragma: no cover
+    parser = create_argument_parser()
+    cmdline_args = parser.parse_args()
     main()

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -55,7 +55,7 @@ def create_argument_parser():
 
     parser.add_argument('-f', '--folds', required=False, default=10,
                         help="number of CV folds (crossvalidation only)")
-    
+
     parser.add_argument('--errors', required=False, default="errors.json",
                         help="output path for the json with wrong predictions")
 

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import io
 import itertools
 import logging
 import shutil
@@ -10,6 +11,7 @@ from collections import defaultdict
 from collections import namedtuple
 
 import numpy as np
+import json
 
 from rasa_nlu import training_data, utils, config
 from rasa_nlu.config import RasaNLUModelConfig
@@ -56,6 +58,15 @@ def create_argument_parser():
 
     parser.add_argument('-f', '--folds', required=False, default=10,
                         help="number of CV folds (crossvalidation only)")
+    
+    parser.add_argument('--errors', required=False, default="errors.json",
+                        help="output path for the json with wrong predictions")
+
+    parser.add_argument('--histogram', required=False, default="hist.png",
+                        help="output path for the confidence histogram")
+
+    parser.add_argument('--confmat', required=False, default="confmat.png",
+                        help="output path for the confusion matrix plot")
 
     utils.add_logging_option_arguments(parser, default=logging.INFO)
 
@@ -101,6 +112,21 @@ def plot_confusion_matrix(cm, classes,
     plt.xlabel('Predicted label')
 
 
+def plot_histogram(hist_data):  # pragma: no cover
+    """Plots a histogram of the confidence distribution of the predictions
+        and saves it to file"""
+    import matplotlib.pyplot as plt
+
+    plt.xlim([0, 1])
+    plt.hist(hist_data, bins=[0.05 * i for i in range(1, 21)])
+    plt.title('Intent Prediction Confidence Distribution')
+    plt.xlabel('Confidence')
+    plt.ylabel('Number of Samples')
+    fig = plt.gcf()
+    fig.set_size_inches(15, 15)
+    fig.savefig(cmdline_args.histogram, bbox_inches='tight')
+
+
 def log_evaluation_table(targets, predictions):  # pragma: no cover
     """Logs the sklearn evaluation metrics"""
     report, precision, f1, accuracy = get_evaluation_metrics(targets,
@@ -135,12 +161,14 @@ def remove_empty_intent_examples(targets, predictions):
     mask = (targets != "") & (targets != None)  # noqa
     targets = targets[mask]
     predictions = np.array(predictions)[mask]
+    messages = np.array(messages)[mask]
+    confidences = np.array(confidences)[mask]
 
     # substitute None values with empty string
     # to enable sklearn evaluation
     predictions[predictions == None] = ""  # noqa
 
-    return targets, predictions
+    return targets, predictions, messages, confidences
 
 
 def clean_intent_labels(labels):
@@ -163,9 +191,32 @@ def drop_intents_below_freq(td, cutoff=5):
     return TrainingData(keep_examples, td.entity_synonyms, td.regex_features)
 
 
-def evaluate_intents(targets, predictions):  # pragma: no cover
-    """Creates a confusion matrix and summary statistics for intent predictions.
+def show_nlu_errors(targets, preds, messages, conf):  # pragma: no cover
+    """Log messages which result in wrong predictions and save them to file"""
 
+    errors = {}
+    errors['nlu'] = [
+        {"text": messages[i],
+            "true_label": targets[i],
+            "prediction": preds[i],
+            "confidence": conf[i]}
+        for i in range(len(messages)) if not (targets[i] == preds[i])]
+
+    if errors['nlu']:
+        errors = json.dumps(errors, indent=4)
+        logger.info("\n\nThese intent examples could not be classified "
+                    "correctly \n{}".format(errors))
+        with io.open(cmdline_args.errors, 'w') as error_file:
+            error_file.write(errors)
+        logger.info("Errors were saved to file {}.".format(cmdline_args.errors))
+    else:
+        logger.info("No prediction errors were found. You are AWESOME!")
+
+
+def evaluate_intents(targets, preds, messages, conf):  # pragma: no cover
+    """Creates a confusion matrix and summary statistics for intent predictions.
+    Log samples which could not be classified correctly and save them to file.
+    Creates a confidence histogram which is saved to file.
     Only considers those examples with a set intent.
     Others are filtered out."""
     from sklearn.metrics import confusion_matrix
@@ -174,17 +225,32 @@ def evaluate_intents(targets, predictions):  # pragma: no cover
 
     # remove empty intent targets
     num_examples = len(targets)
-    targets, predictions = remove_empty_intent_examples(targets, predictions)
+    targets, preds, messages, conf = remove_empty_intent_examples(
+                                                targets, preds, messages, conf)
+
     logger.info("Intent Evaluation: Only considering those "
                 "{} examples that have a defined intent out "
                 "of {} examples".format(targets.size, num_examples))
-    log_evaluation_table(targets, predictions)
+    log_evaluation_table(targets, preds)
 
-    cnf_matrix = confusion_matrix(targets, predictions)
-    labels = unique_labels(targets, predictions)
-    plot_confusion_matrix(cnf_matrix,
-                          classes=labels,
+    # log and save misclassified samples to file for debugging
+    show_nlu_errors(targets, preds, messages, conf)
+
+    cnf_matrix = confusion_matrix(targets, preds)
+    labels = unique_labels(targets, preds)
+    plot_confusion_matrix(cnf_matrix, classes=labels,
                           title='Intent Confusion matrix')
+    # save confusion matrix to file before showing it
+    fig = plt.gcf()
+    fig.set_size_inches(15, 15)
+    fig.savefig(cmdline_args.confmat, bbox_inches='tight')
+
+    plt.show()
+
+    # create histogram of confidence distribution, save to file and display
+    plt.gcf().clear()
+    hist = [conf[i] for i in range(len(messages)) if (targets[i] == preds[i])]
+    plot_histogram(hist)
 
     plt.show()
 

--- a/tests/base/test_evaluation.py
+++ b/tests/base/test_evaluation.py
@@ -243,11 +243,15 @@ def test_run_cv_evaluation():
 def test_empty_intent_removal():
     targets = ["", "greet"]
     predicted = ["restaurant_search", "greet"]
-
-    targets_r, predicted_r = remove_empty_intent_examples(targets, predicted)
+    messages = ["I am hungry", "hello"]
+    conf = ["0.12345", "0.98765"]
+    targets_r, predicted_r, messages_r, conf_r = remove_empty_intent_examples(
+                                            targets, predicted, messages, conf)
 
     assert targets_r == ["greet"]
     assert predicted_r == ["greet"]
+    assert messages_r == ["hello"]
+    assert conf_r == ["0.98765"]
 
 
 def test_evaluate_entities():


### PR DESCRIPTION
**Proposed changes**:
- log the intent samples which failed during evaluation with text, prediction confidence and true label
- show and save histogram of confidence scores
- auto-save confusion-matrix

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
