### PR TITLE
resolve encoding issue in error.json

### DIFF
--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -201,7 +201,7 @@ def drop_intents_below_freq(td, cutoff=5):
 def save_nlu_errors(errors, filename):
     """Write out nlu classification errors to a file."""
 
-    utils.write_to_file(filename, json.dumps(errors, indent=4))
+    utils.write_to_file(filename, json.dumps(errors, indent=4, ensure_ascii=False))
     logger.info("Model prediction errors saved to {}.".format(filename))
 
 


### PR DESCRIPTION
Regarding issue #1289, using `ensure_ascii=False` in the parameter of json dump inside the `save_nlu_errors` function, non-ascii characters will be show correctly in the `error.json` file.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
