### PR TITLE
Pass duckling reference time in miliseconds

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Removed
 
 Fixed
 -----
+- correctly pass reference time in miliseconds to duckling_http
 
 [0.13.0] - 2018-08-02
 ^^^^^^^^^^^^^^^^^^^^^

--- a/rasa_nlu/extractors/duckling_http_extractor.py
+++ b/rasa_nlu/extractors/duckling_http_extractor.py
@@ -116,13 +116,14 @@ class DucklingHTTPExtractor(EntityExtractor):
     def _reference_time_from_message(message):
         if message.time is not None:
             try:
-                return int(message.time)
+                return int(message.time)*1000
             except ValueError as e:
                 logging.warning("Could not parse timestamp {}. Instead "
                                 "current UTC time will be passed to "
                                 "duckling. Error: {}".format(message.time, e))
-        # fallbacks to current time
-        return int(time.time())
+        # fallbacks to current time, multiplied by 1000 because duckling
+        # requires the reftime in miliseconds
+        return int(time.time())*1000
 
     def process(self, message, **kwargs):
         # type: (Message, **Any) -> None

--- a/rasa_nlu/extractors/duckling_http_extractor.py
+++ b/rasa_nlu/extractors/duckling_http_extractor.py
@@ -116,14 +116,14 @@ class DucklingHTTPExtractor(EntityExtractor):
     def _reference_time_from_message(message):
         if message.time is not None:
             try:
-                return int(message.time)*1000
+                return int(message.time) * 1000
             except ValueError as e:
                 logging.warning("Could not parse timestamp {}. Instead "
                                 "current UTC time will be passed to "
                                 "duckling. Error: {}".format(message.time, e))
         # fallbacks to current time, multiplied by 1000 because duckling
         # requires the reftime in miliseconds
-        return int(time.time())*1000
+        return int(time.time()) * 1000
 
     def process(self, message, **kwargs):
         # type: (Message, **Any) -> None


### PR DESCRIPTION
**Proposed changes**:
- we were passing it in seconds previously, but duckling needs it in miliseconds and so it was just showing the current date to be in 1970 😄 
- fixes #1291 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
