### PR TITLE
ADD default value of errors_filename to run_evaluation

### DIFF
--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -603,7 +603,7 @@ def remove_duckling_entities(entity_predictions):
 
 
 def run_evaluation(data_path, model_path,
-                   errors_filename=None,
+                   errors_filename='errors.json',
                    confmat_filename=None,
                    intent_hist_filename=None,
                    component_builder=None):  # pragma: no cover


### PR DESCRIPTION
**Proposed changes**:
`run_evaluation` has `errors_filename` as optional param.
it passed to `evaluate_intents` but the func assumed that value is valid (not None)
so when you don't pass it, it riases an exception in `save_nlu_errors`.
while I can understand that `run_evaluation` to be called from `main` and it pass default value 
if caller doesn't provide the value but you can't expect that caller will always use `evaluate.main` to call `run_evaluation`. thus I propose add same default value to `run_evaluation`.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
