### PR TITLE
fix for the issue #1298 

### DIFF
--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -173,7 +173,7 @@ def remove_empty_intent_examples(intent_results):
         # substitute None values with empty string
         # to enable sklearn evaluation
         if r.prediction is None:
-            r.prediction = ""
+            r = r._replace(prediction="")
 
         if r.target != "" and r.target is not None:
             filtered.append(r)


### PR DESCRIPTION
Fix for the issue #1298 (namedtuple bug in evaluate.py)  on all-zero embedding vectors and replacing None with empty string in evaluation script 

**Proposed changes**:
- replace line 176 in evaluate.py with r = r._replace(prediction="")

**Status (please check what you already did)**:
- [X] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
