### PR TITLE
Fix whitespace tokenizer for french

### DIFF
--- a/rasa_nlu/model.py
+++ b/rasa_nlu/model.py
@@ -171,10 +171,10 @@ class Trainer(object):
     def train(self, data, **kwargs):
         # type: (TrainingData) -> Interpreter
         """Trains the underlying pipeline using the provided training data."""
-
         self.training_data = data
 
         context = kwargs  # type: Dict[Text, Any]
+        context['language'] = self.config.get('language')
 
         for component in self.pipeline:
             updates = component.provide_context()

--- a/rasa_nlu/tokenizers/whitespace_tokenizer.py
+++ b/rasa_nlu/tokenizers/whitespace_tokenizer.py
@@ -22,21 +22,22 @@ class WhitespaceTokenizer(Tokenizer, Component):
         # type: (TrainingData, RasaNLUModelConfig, **Any) -> None
 
         for example in training_data.training_examples:
-            example.set("tokens", self.tokenize(example.text))
+            example.set("tokens", self.tokenize(example.text, **kwargs))
 
     def process(self, message, **kwargs):
         # type: (Message, **Any) -> None
 
-        message.set("tokens", self.tokenize(message.text))
+        message.set("tokens", self.tokenize(message.text, **kwargs))
 
-    def tokenize(self, text):
-        # type: (Text) -> List[Token]
+    def tokenize(self, text, **kwargs):
+        # type: (Text, **Any) -> List[Token]
 
         # there is space or end of string after punctuation
         # because we do not want to replace 10.000 with 10 000
         words = re.sub(r'[.,!?]+(\s|$)', ' ', text).split()
 
-        if lang == 'fr':
+        # Detect if the processed language is French
+        if 'language' in kwargs and kwargs['language'] == 'fr':
             words = re.compile(r"""(?xumsi)
                                    (?:[lcdjmnts]|qu)['’]
                                    | http:[^\s]+\.\w{2,3}
@@ -47,9 +48,11 @@ class WhitespaceTokenizer(Tokenizer, Component):
 
         running_offset = 0
         tokens = []
+
         for word in words:
             word_offset = text.index(word, running_offset)
             word_len = len(word)
             running_offset = word_offset + word_len
             tokens.append(Token(word, word_offset))
+
         return tokens

--- a/rasa_nlu/tokenizers/whitespace_tokenizer.py
+++ b/rasa_nlu/tokenizers/whitespace_tokenizer.py
@@ -36,6 +36,15 @@ class WhitespaceTokenizer(Tokenizer, Component):
         # because we do not want to replace 10.000 with 10 000
         words = re.sub(r'[.,!?]+(\s|$)', ' ', text).split()
 
+        if lang == 'fr':
+            words = re.compile(r"""(?xumsi)
+                                   (?:[lcdjmnts]|qu)['’]
+                                   | http:[^\s]+\.\w{2,3}
+                                   | \d+[.,]\d+
+                                   | [.-]+
+                                   | \w+
+                                   | [^\w\s]""").findall(text)
+
         running_offset = 0
         tokens = []
         for word in words:

--- a/tests/base/test_tokenizers.py
+++ b/tests/base/test_tokenizers.py
@@ -10,12 +10,19 @@ import mock
 def test_whitespace():
     from rasa_nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
     tk = WhitespaceTokenizer()
+    lang = {"language": "fr"}
 
     assert [t.text for t in tk.tokenize("Forecast for lunch")] == \
            ['Forecast', 'for', 'lunch']
 
     assert [t.offset for t in tk.tokenize("Forecast for lunch")] == \
            [0, 9, 13]
+
+    assert [t.text for t in tk.tokenize("La marche de l'ouest", **lang)] == \
+           ['La', 'marche', 'de', "l'", 'ouest']
+
+    assert [t.offset for t in tk.tokenize("La marche de l'ouest", **lang)] == \
+           [0, 3, 10, 13, 15]
 
     # we ignore .,!?
     assert [t.text for t in tk.tokenize("hey ńöñàśçií how're you?")] == \

--- a/tests/training/test_train.py
+++ b/tests/training/test_train.py
@@ -55,6 +55,8 @@ def pipelines_for_tests():
                                "ner_mitie",
                                "intent_classifier_sklearn",
                                )),
+            ("fr", as_pipeline("tokenizer_whitespace",
+                               )),
             ]
 
 


### PR DESCRIPTION
**Proposed changes**:
- Better whitespace tokenization handling for French language when using tensorflow pipeline.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog

I don't see what to change in the documentation. Any idea?