### PR TITLE
Add missing scipy dependency to tensorflow pipeline extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ extras_requires = {
               ],
     'tensorflow': ["scikit-learn",
                    "tensorflow",
-                   "sklearn-crfsuite"
+                   "sklearn-crfsuite",
+                   "scipy"
                    ],
     'mitie': ["mitie"],
 }

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,9 @@ extras_requires = {
               "spacy>2.0",
               ],
     'tensorflow': ["scikit-learn",
-                   "tensorflow",
                    "sklearn-crfsuite",
-                   "scipy"
+                   "scipy",
+                   "tensorflow"
                    ],
     'mitie': ["mitie"],
 }


### PR DESCRIPTION
**Proposed changes**:
- Add missing `scipy` dependency to tensorflow pipeline extras - should fix most parts of #1315

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
