### PR TITLE
Run Evaluation from python API

### DIFF
--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -606,8 +606,21 @@ def run_evaluation(data_path, model_path,
                    errors_filename='errors.json',
                    confmat_filename=None,
                    intent_hist_filename=None,
+                   component_builder=None):
+    """Wrapper for _run_evaluation().  May be called from the python API and 
+    will log results to the console"""
+    utils.configure_colored_logging(logging.INFO)
+    _run_evaluation(data_path, model_path, errors_filename, confmat_filename,
+                   intent_hist_filename, component_builder)
+
+
+def _run_evaluation(data_path, model_path,
+                   errors_filename='errors.json',
+                   confmat_filename=None,
+                   intent_hist_filename=None,
                    component_builder=None):  # pragma: no cover
-    """Evaluate intent classification and entity extraction."""
+    """Evaluate intent classification and entity extraction.
+    Is run when evaluate is called from command line"""
 
     # get the metadata config from the package data
     interpreter = Interpreter.load(model_path, component_builder)
@@ -830,7 +843,7 @@ def main():
             return_entity_results(entity_results.test, "test")
 
     elif cmdline_args.mode == "evaluation":
-        run_evaluation(cmdline_args.data,
+        _run_evaluation(cmdline_args.data,
                        cmdline_args.model,
                        cmdline_args.errors,
                        cmdline_args.confmat,

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -607,18 +607,18 @@ def run_evaluation(data_path, model_path,
                    confmat_filename=None,
                    intent_hist_filename=None,
                    component_builder=None):
-    """Wrapper for run_evaluation_cli().  May be called from the python API and 
-    will log results to the console"""
+    """Wrapper for run_evaluation_cli().  May be called from the
+    python API and  will log results to the console"""
     utils.configure_colored_logging(logging.INFO)
     run_evaluation_cli(data_path, model_path, errors_filename, confmat_filename,
-                   intent_hist_filename, component_builder)
+                       intent_hist_filename, component_builder)
 
 
 def run_evaluation_cli(data_path, model_path,
-                   errors_filename='errors.json',
-                   confmat_filename=None,
-                   intent_hist_filename=None,
-                   component_builder=None):  # pragma: no cover
+                       errors_filename='errors.json',
+                       confmat_filename=None,
+                       intent_hist_filename=None,
+                       component_builder=None):  # pragma: no cover
     """Evaluate intent classification and entity extraction.
     Is run when evaluate is called from command line"""
 
@@ -844,10 +844,10 @@ def main():
 
     elif cmdline_args.mode == "evaluation":
         run_evaluation_cli(cmdline_args.data,
-                       cmdline_args.model,
-                       cmdline_args.errors,
-                       cmdline_args.confmat,
-                       cmdline_args.histogram)
+                           cmdline_args.model,
+                           cmdline_args.errors,
+                           cmdline_args.confmat,
+                           cmdline_args.histogram)
 
     logger.info("Finished evaluation")
 

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -607,14 +607,14 @@ def run_evaluation(data_path, model_path,
                    confmat_filename=None,
                    intent_hist_filename=None,
                    component_builder=None):
-    """Wrapper for _run_evaluation().  May be called from the python API and 
+    """Wrapper for run_evaluation_cli().  May be called from the python API and 
     will log results to the console"""
     utils.configure_colored_logging(logging.INFO)
-    _run_evaluation(data_path, model_path, errors_filename, confmat_filename,
+    run_evaluation_cli(data_path, model_path, errors_filename, confmat_filename,
                    intent_hist_filename, component_builder)
 
 
-def _run_evaluation(data_path, model_path,
+def run_evaluation_cli(data_path, model_path,
                    errors_filename='errors.json',
                    confmat_filename=None,
                    intent_hist_filename=None,
@@ -843,7 +843,7 @@ def main():
             return_entity_results(entity_results.test, "test")
 
     elif cmdline_args.mode == "evaluation":
-        _run_evaluation(cmdline_args.data,
+        run_evaluation_cli(cmdline_args.data,
                        cmdline_args.model,
                        cmdline_args.errors,
                        cmdline_args.confmat,


### PR DESCRIPTION
Currently, if `rasa_nlu.evaluate` is run via command line, the evaluation metrics are printed by the logger.  Ideally, we would like to be able to grab the evaluation metrics if, instead, functions in `evaluate` are called from the python API.

**Proposed changes**:
- Renames existing `run_evaluation()` function to `run_evaluation_cmi()` to indicate that this is the one called when running `evaluate` via command line.
- Adds `run_evaluation()` function that wraps `run_evaluation_cmi` and may be called from python API to print metrics to stdout.
- Will add functionality to load these metrics into python variables.

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
