### PR TITLE
Separate confidence distributions histograms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,11 +12,11 @@ This project adheres to `Semantic Versioning`_ starting with version 0.7.0.
 Added
 -----
 
- - Added command line argument for evaluate script allowing to plot separately
-   confidence distributions for wrong and correct predictions in one same histogram.
-
 Changed
 -------
+
+- Changed evaluate behaviour to plot two histogram bars per bin.
+  Plotting confidence of right predictions in green and wrong in red.
 
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ This project adheres to `Semantic Versioning`_ starting with version 0.7.0.
 Added
 -----
 
+ - New command line argument for ``evaluate.py`` script allowing to plot separately confidence
+distributions for wrong and correct predictions in one same histogram.
+
 Changed
 -------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,8 @@ Changed
 -------
 
 - Changed evaluate behaviour to plot two histogram bars per bin.
-  Plotting confidence of right predictions in green and wrong in red.
+  Plotting confidence of right predictions in a wine-ish colour
+  and wrong ones in a blue-ish colour.
 
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,8 +12,8 @@ This project adheres to `Semantic Versioning`_ starting with version 0.7.0.
 Added
 -----
 
- - New command line argument for ``evaluate.py`` script allowing to plot separately confidence
-distributions for wrong and correct predictions in one same histogram.
+ - Added command line argument for evaluate script allowing to plot separately
+   confidence distributions for wrong and correct predictions in one same histogram.
 
 Changed
 -------

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -85,6 +85,11 @@ Samples which have not been predicted correctly are logged and saved to a file
 called ``errors.json`` for easier debugging. 
 Finally, the evaluation script creates a histogram of the confidence distribution for all predictions. 
 Improving the quality of your training data will move the histogram bars to the right.
+By default the histogram will show the confidence distribution of all predictions regardless
+of the prediction being correct or wrong.
+If you want to visualize the confidence distributions for wrong predictions and
+correct predictions as separate bars of the histogram, you can do so by passing the following
+flag to the evaluation script: ``--dual_histogram``.
 
 .. note::
     A confusion matrix will **only** be created if you are evaluating a model on a test set.

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -83,13 +83,12 @@ Furthermore, it creates a confusion matrix for you to see which
 intents are mistaken for which others.
 Samples which have not been predicted correctly are logged and saved to a file 
 called ``errors.json`` for easier debugging. 
-Finally, the evaluation script creates a histogram of the confidence distribution for all predictions. 
-Improving the quality of your training data will move the histogram bars to the right.
-By default the histogram will show the confidence distribution of all predictions regardless
-of the prediction being correct or wrong.
-If you want to visualize the confidence distributions for wrong predictions and
-correct predictions as separate bars of the histogram, you can do so by passing the following
-flag to the evaluation script: ``--dual_histogram``.
+Finally, the evaluation script creates a histogram of the confidence distribution for all predictions,
+separating the confidence of wrong and correct predictions in different bars of the histogram.
+Improving the quality of your training data will move the green histogram bars
+(confidence of the correct predictions) to the right and the red histogram bars
+(confidence of wrong predictions) to the left.
+
 
 .. note::
     A confusion matrix will **only** be created if you are evaluating a model on a test set.

--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -85,8 +85,8 @@ Samples which have not been predicted correctly are logged and saved to a file
 called ``errors.json`` for easier debugging. 
 Finally, the evaluation script creates a histogram of the confidence distribution for all predictions,
 separating the confidence of wrong and correct predictions in different bars of the histogram.
-Improving the quality of your training data will move the green histogram bars
-(confidence of the correct predictions) to the right and the red histogram bars
+Improving the quality of your training data will move the blue-ish histogram bars
+(confidence of the correct predictions) to the right and the wine-ish histogram bars
 (confidence of wrong predictions) to the left.
 
 

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -71,10 +71,6 @@ def create_argument_parser():
     parser.add_argument('--confmat', required=False, default="confmat.png",
                         help="output path for the confusion matrix plot")
 
-    parser.add_argument('--dual_histogram', action='store_true',
-                        help="Plot errors and correct predictions confidence "
-                             "as separate histogram bars")
-
     utils.add_logging_option_arguments(parser, default=logging.INFO)
 
     return parser
@@ -126,17 +122,14 @@ def plot_confusion_matrix(cm, classes,
         fig.savefig(out, bbox_inches='tight')
 
 
-def plot_histogram(hist_data, dual_hist, out=None):    # pragma: no cover
+def plot_histogram(hist_data, out=None):    # pragma: no cover
     """Plot a histogram of the confidence distribution of the predictions in
     two columns.
     Green for the confidences of hits, Red for the confidences of misses.
     Saves the plot to a file."""
     import matplotlib.pyplot as plt
 
-    colors = None
-    if dual_hist:
-        colors = ['#59c16a', '#f77f76']
-
+    colors = ['#59c16a', '#f77f76']
     bins = [0.05 * i for i in range(1, 21)]
 
     plt.xlim([0, 1])
@@ -145,10 +138,7 @@ def plot_histogram(hist_data, dual_hist, out=None):    # pragma: no cover
     plt.title('Intent Prediction Confidence Distribution')
     plt.xlabel('Confidence')
     plt.ylabel('Number of Samples')
-
-    if dual_hist:
-        # In the dual histogram case add legend to the plot
-        plt.legend(['hits', 'misses'])
+    plt.legend(['hits', 'misses'])
 
     if out:
         fig = plt.gcf()
@@ -246,41 +236,29 @@ def collect_nlu_errors(intent_results):  # pragma: no cover
         return None
 
 
-def plot_intent_confidences(intent_results, intent_hist_filename, dual_hist):
+def plot_intent_confidences(intent_results, intent_hist_filename):
     import matplotlib.pyplot as plt
     # create histogram of confidence distribution, save to file and display
     plt.gcf().clear()
-    if dual_hist:
-        pos_hist = [
-            r.confidence
-            for r in intent_results
-            if r.target == r.prediction
-        ]
-        neg_hist = [
-            r.confidence
-            for r in intent_results
-            if r.target != r.prediction
-        ]
-        hist = [pos_hist, neg_hist]
-    else:
-        hist = [
-            r.confidence
-            for r in intent_results
-            if r.target == r.prediction
-        ]
+    pos_hist = [
+        r.confidence
+        for r in intent_results if r.target == r.prediction]
 
-    plot_histogram(hist, dual_hist, intent_hist_filename)
+    neg_hist = [
+            r.confidence
+            for r in intent_results if r.target != r.prediction]
+
+    plot_histogram([pos_hist, neg_hist], intent_hist_filename)
 
 
 def evaluate_intents(intent_results,
                      errors_filename,
                      confmat_filename,
-                     intent_hist_filename,
-                     dual_hist):  # pragma: no cover
+                     intent_hist_filename):  # pragma: no cover
     """Creates a confusion matrix and summary statistics for intent predictions.
     Log samples which could not be classified correctly and save them to file.
     Creates a confidence histogram which is saved to file.
-    If dual_hist==True then wrong and correct prediction confidences will be
+    Wrong and correct prediction confidences will be
     plotted in separate bars of the same histogram plot.
     Only considers those examples with a set intent.
     Others are filtered out."""
@@ -312,8 +290,7 @@ def evaluate_intents(intent_results,
     plt.show()
 
     plot_intent_confidences(intent_results,
-                            intent_hist_filename,
-                            dual_hist)
+                            intent_hist_filename)
 
     plt.show()
 
@@ -642,7 +619,6 @@ def run_evaluation(data_path, model_path,
                    errors_filename='errors.json',
                    confmat_filename=None,
                    intent_hist_filename=None,
-                   dual_hist=False,
                    component_builder=None):  # pragma: no cover
     """Evaluate intent classification and entity extraction."""
 
@@ -664,7 +640,7 @@ def run_evaluation(data_path, model_path,
         logger.info("Intent evaluation results:")
 
         evaluate_intents(intent_results, errors_filename, confmat_filename,
-                         intent_hist_filename, dual_hist)
+                         intent_hist_filename)
 
     if extractors:
         entity_targets = get_entity_targets(test_data)
@@ -871,8 +847,7 @@ def main():
                        cmdline_args.model,
                        cmdline_args.errors,
                        cmdline_args.confmat,
-                       cmdline_args.histogram,
-                       cmdline_args.dual_histogram)
+                       cmdline_args.histogram)
 
     logger.info("Finished evaluation")
 

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -127,14 +127,14 @@ def plot_confusion_matrix(cm, classes,
 
 
 def plot_histogram(hist_data, dual_hist, out=None):    # pragma: no cover
-    """Plot a histogram of the confidence distribution of the predictions in two columns.
+    """Plot a histogram of the confidence distribution of the predictions in
+    two columns.
     Green for the confidences of hits, Red for the confidences of misses.
     Saves the plot to a file."""
     import matplotlib.pyplot as plt
 
     colors = None
     if dual_hist:
-        # Change colors to green and red for correct and wrong prediction confidences respectively
         colors = ['#59c16a', '#f77f76']
 
     bins = [0.05 * i for i in range(1, 21)]
@@ -263,7 +263,11 @@ def plot_intent_confidences(intent_results, intent_hist_filename, dual_hist):
         ]
         hist = [pos_hist, neg_hist]
     else:
-        hist = [r.confidence for r in intent_results if r.target == r.prediction]
+        hist = [
+            r.confidence
+            for r in intent_results
+            if r.target == r.prediction
+        ]
 
     plot_histogram(hist, dual_hist, intent_hist_filename)
 
@@ -808,7 +812,7 @@ def compute_entity_metrics(interpreter, corpus):
 def return_results(results, dataset_name):
     """Returns results of crossvalidation
     :param results: dictionary of results returned from cv
-    :param dataset: string of which dataset the results are from, e.g.
+    :param dataset_name: string of which dataset the results are from, e.g.
                     test/train
     """
 
@@ -821,7 +825,7 @@ def return_results(results, dataset_name):
 def return_entity_results(results, dataset_name):
     """Returns entity results of crossvalidation
     :param results: dictionary of dictionaries of results returned from cv
-    :param dataset: string of which dataset the results are from, e.g.
+    :param dataset_name: string of which dataset the results are from, e.g.
                     test/train
     """
     for extractor, result in results.items():

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -125,11 +125,12 @@ def plot_confusion_matrix(cm, classes,
 def plot_histogram(hist_data, out=None):    # pragma: no cover
     """Plot a histogram of the confidence distribution of the predictions in
     two columns.
-    Green for the confidences of hits, Red for the confidences of misses.
+    Wine-ish colour for the confidences of hits.
+    Blue-ish colour for the confidences of misses.
     Saves the plot to a file."""
     import matplotlib.pyplot as plt
 
-    colors = ['#59c16a', '#f77f76']
+    colors = ['#009292', '#920000']     #
     bins = [0.05 * i for i in range(1, 21)]
 
     plt.xlim([0, 1])

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -54,7 +54,7 @@ def create_argument_parser():
 
     # todo: make the two different modes two subparsers
     parser.add_argument('-c', '--config',
-                        help="model configurion file (crossvalidation only)")
+                        help="model configuration file (crossvalidation only)")
 
     parser.add_argument('-m', '--model', required=False,
                         help="path to model (evaluation only)")
@@ -70,6 +70,10 @@ def create_argument_parser():
 
     parser.add_argument('--confmat', required=False, default="confmat.png",
                         help="output path for the confusion matrix plot")
+
+    parser.add_argument('--dual_histogram', action='store_true',
+                        help="Plot errors and correct predictions confidence "
+                             "as separate histogram bars")
 
     utils.add_logging_option_arguments(parser, default=logging.INFO)
 
@@ -122,18 +126,29 @@ def plot_confusion_matrix(cm, classes,
         fig.savefig(out, bbox_inches='tight')
 
 
-def plot_histogram(hist_data,
-                   out=None):  # pragma: no cover
-    """Plot a histogram of the confidence distribution of the predictions.
-
+def plot_histogram(hist_data, dual_hist, out=None):    # pragma: no cover
+    """Plot a histogram of the confidence distribution of the predictions in two columns.
+    Green for the confidences of hits, Red for the confidences of misses.
     Saves the plot to a file."""
     import matplotlib.pyplot as plt
 
+    colors = None
+    if dual_hist:
+        # Change colors to green and red for correct and wrong prediction confidences respectively
+        colors = ['#59c16a', '#f77f76']
+
+    bins = [0.05 * i for i in range(1, 21)]
+
     plt.xlim([0, 1])
-    plt.hist(hist_data, bins=[0.05 * i for i in range(1, 21)])
+    plt.hist(hist_data, bins=bins, color=colors)
+    plt.xticks(bins)
     plt.title('Intent Prediction Confidence Distribution')
     plt.xlabel('Confidence')
     plt.ylabel('Number of Samples')
+
+    if dual_hist:
+        # In the dual histogram case add legend to the plot
+        plt.legend(['hits', 'misses'])
 
     if out:
         fig = plt.gcf()
@@ -231,22 +246,38 @@ def collect_nlu_errors(intent_results):  # pragma: no cover
         return None
 
 
-def plot_intent_confidences(intent_results, intent_hist_filename):
+def plot_intent_confidences(intent_results, intent_hist_filename, dual_hist):
     import matplotlib.pyplot as plt
     # create histogram of confidence distribution, save to file and display
     plt.gcf().clear()
-    hist = [r.confidence for r in intent_results if r.target == r.prediction]
-    plot_histogram(hist, intent_hist_filename)
+    if dual_hist:
+        pos_hist = [
+            r.confidence
+            for r in intent_results
+            if r.target == r.prediction
+        ]
+        neg_hist = [
+            r.confidence
+            for r in intent_results
+            if r.target != r.prediction
+        ]
+        hist = [pos_hist, neg_hist]
+    else:
+        hist = [r.confidence for r in intent_results if r.target == r.prediction]
+
+    plot_histogram(hist, dual_hist, intent_hist_filename)
 
 
 def evaluate_intents(intent_results,
                      errors_filename,
                      confmat_filename,
                      intent_hist_filename,
-                     ):  # pragma: no cover
+                     dual_hist):  # pragma: no cover
     """Creates a confusion matrix and summary statistics for intent predictions.
     Log samples which could not be classified correctly and save them to file.
     Creates a confidence histogram which is saved to file.
+    If dual_hist==True then wrong and correct prediction confidences will be
+    plotted in separate bars of the same histogram plot.
     Only considers those examples with a set intent.
     Others are filtered out."""
     from sklearn.metrics import confusion_matrix
@@ -277,7 +308,8 @@ def evaluate_intents(intent_results,
     plt.show()
 
     plot_intent_confidences(intent_results,
-                            intent_hist_filename)
+                            intent_hist_filename,
+                            dual_hist)
 
     plt.show()
 
@@ -606,6 +638,7 @@ def run_evaluation(data_path, model_path,
                    errors_filename='errors.json',
                    confmat_filename=None,
                    intent_hist_filename=None,
+                   dual_hist=False,
                    component_builder=None):  # pragma: no cover
     """Evaluate intent classification and entity extraction."""
 
@@ -627,7 +660,7 @@ def run_evaluation(data_path, model_path,
         logger.info("Intent evaluation results:")
 
         evaluate_intents(intent_results, errors_filename, confmat_filename,
-                         intent_hist_filename)
+                         intent_hist_filename, dual_hist)
 
     if extractors:
         entity_targets = get_entity_targets(test_data)
@@ -834,7 +867,8 @@ def main():
                        cmdline_args.model,
                        cmdline_args.errors,
                        cmdline_args.confmat,
-                       cmdline_args.histogram)
+                       cmdline_args.histogram,
+                       cmdline_args.dual_histogram)
 
     logger.info("Finished evaluation")
 


### PR DESCRIPTION
**Proposed changes**:
- Change `evaluate.py` script to allow for separate histogram bars plotting wrong and correct intent predictions confidence distributions.

Changes related to issue #1354

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
