### PR TITLE
fixed entity regex for markdown files. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ rasa_nlu/tmbo_test.py
 *.tar.gz
 docs/key
 docs/key.pub
+.pytest_cache

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Removed
 
 Fixed
 -----
+- re-added support for entity names with special characters in markdown format
 
 [0.13.2] - 2018-08-28
 ^^^^^^^^^^^^^^^^^^^^^

--- a/rasa_nlu/training_data/formats/markdown.py
+++ b/rasa_nlu/training_data/formats/markdown.py
@@ -17,7 +17,7 @@ SYNONYM = "synonym"
 REGEX = "regex"
 available_sections = [INTENT, SYNONYM, REGEX]
 ent_regex = re.compile(r'\[(?P<entity_text>[^\]]+)'
-                       r'\]\((?P<entity>\w*?)'
+                       r'\]\((?P<entity>[^:)]*?)'
                        r'(?:\:(?P<value>[^)]+))?\)')  # [entity_text](entity_type(:entity_synonym)?)
 
 item_regex = re.compile(r'\s*[-\*+]\s*(.+)')

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -14,6 +14,7 @@ from rasa_nlu import utils
 from rasa_nlu.convert import convert_training_data
 from rasa_nlu.extractors.mitie_entity_extractor import MitieEntityExtractor
 from rasa_nlu.tokenizers.whitespace_tokenizer import WhitespaceTokenizer
+from rasa_nlu.training_data.formats import MarkdownReader
 from rasa_nlu.training_data.formats.rasa import validate_rasa_nlu_data
 
 
@@ -380,3 +381,50 @@ def test_url_data_format():
     data = utils.read_json_file(fname)
     assert data is not None
     validate_rasa_nlu_data(data)
+
+
+def test_markdown_entity_regex():
+    r = MarkdownReader()
+
+    md = """
+## intent:restaurant_search
+- i'm looking for a place to eat
+- i'm looking for a place in the [north](loc-direction) of town
+- show me [chines](cuisine:chinese) restaurants
+- show me [chines](22_ab-34*3.A:43er*+?df) restaurants
+    """
+
+    result = r.reads(md)
+
+    assert len(result.training_examples) == 4
+    first = result.training_examples[0]
+    assert first.data == {"intent": "restaurant_search"}
+    assert first.text == "i'm looking for a place to eat"
+
+    second = result.training_examples[1]
+    assert second.data == {'intent': 'restaurant_search',
+                           'entities': [
+                               {'start': 31,
+                                'end': 36,
+                                'value': 'north',
+                                'entity': 'loc-direction'}
+                           ]}
+    assert second.text == "i'm looking for a place in the north of town"
+
+    third = result.training_examples[2]
+    assert third.data == {'intent': 'restaurant_search',
+                          'entities': [
+                              {'start': 8,
+                               'end': 14,
+                               'value': 'chinese',
+                               'entity': 'cuisine'}]}
+    assert third.text == "show me chines restaurants"
+
+    fourth = result.training_examples[3]
+    assert fourth.data == {'intent': 'restaurant_search',
+                           'entities': [
+                               {'start': 8,
+                                'end': 14,
+                                'value': '43er*+?df',
+                                'entity': '22_ab-34*3.A'}]}
+    assert fourth.text == "show me chines restaurants"


### PR DESCRIPTION
**Proposed changes**:
- fixed entity regex for markdown files to support special characters in the entity name (e.g. `-` or `#`)
- characters not allowed: `:` and `)`
- fixes #1360

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
