### PR TITLE
Lazy-import boto3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Changed
 -------
 - Training data is now validated after loading from files in ``loading.py`` instead of on initialisation of
   ``TrainingData`` object
+- ``boto3`` is now loaded lazily in ``AWSPersistor`` and is not included in ``requirements_bare.txt`` anymore
 
 Removed
 -------

--- a/alt_requirements/requirements_bare.txt
+++ b/alt_requirements/requirements_bare.txt
@@ -1,7 +1,6 @@
 gevent==1.2.2
 klein==17.10.0
 hyperlink==17.3.1
-boto3==1.5.20
 typing==3.6.2
 future==0.16.0
 six==1.11.0

--- a/alt_requirements/requirements_dev.txt
+++ b/alt_requirements/requirements_dev.txt
@@ -16,3 +16,4 @@ httpretty==0.9.5
 # other
 google-cloud-storage==1.7.0
 azure-storage-blob==1.0.0
+boto3==1.5.20

--- a/rasa_nlu/persistor.py
+++ b/rasa_nlu/persistor.py
@@ -9,8 +9,6 @@ import os
 import shutil
 import tarfile
 
-import boto3
-import botocore
 from builtins import object
 from typing import Optional, Tuple, List, Text
 
@@ -143,6 +141,7 @@ class AWSPersistor(Persistor):
 
     def __init__(self, bucket_name, endpoint_url=None):
         # type: (Text, Optional[Text]) -> None
+        import boto3
         super(AWSPersistor, self).__init__()
         self.s3 = boto3.resource('s3', endpoint_url=endpoint_url)
         self._ensure_bucket_exists(bucket_name)
@@ -173,6 +172,8 @@ class AWSPersistor(Persistor):
             return []
 
     def _ensure_bucket_exists(self, bucket_name):
+        import boto3
+        import botocore
         bucket_config = {
             'LocationConstraint': boto3.DEFAULT_SESSION.region_name}
         try:

--- a/tests/base/test_persistor.py
+++ b/tests/base/test_persistor.py
@@ -7,6 +7,8 @@ import os
 
 import mock
 import pytest
+import boto3
+import botocore
 from moto import mock_s3
 
 from tests import utilities


### PR DESCRIPTION
**Proposed changes**:
- Lazy-import for `boto3` and `botocore` since they are only used for persisting the model to S3.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
