### PR TITLE
Fix DialogFlow emulator response to match API

### DIFF
--- a/rasa_nlu/emulators/dialogflow.py
+++ b/rasa_nlu/emulators/dialogflow.py
@@ -46,7 +46,7 @@ class DialogflowEmulator(NoEmulator):
                 "metadata": {
                     "intentId": str(uuid.uuid1()),
                     "webhookUsed": "false",
-                    "intentName": data["intent"]
+                    "intentName": data["intent"]["name"]
                 },
                 "fulfillment": {},
                 "score": data["intent"]["confidence"],

--- a/rasa_nlu/emulators/dialogflow.py
+++ b/rasa_nlu/emulators/dialogflow.py
@@ -40,7 +40,7 @@ class DialogflowEmulator(NoEmulator):
                 "source": "agent",
                 "resolvedQuery": data["text"],
                 "action": data["intent"]["name"],
-                "actionIncomplete": None,
+                "actionIncomplete": False,
                 "parameters": entities,
                 "contexts": [],
                 "metadata": {

--- a/rasa_nlu/emulators/dialogflow.py
+++ b/rasa_nlu/emulators/dialogflow.py
@@ -39,7 +39,7 @@ class DialogflowEmulator(NoEmulator):
             "result": {
                 "source": "agent",
                 "resolvedQuery": data["text"],
-                "action": None,
+                "action": data["intent"]["name"],
                 "actionIncomplete": None,
                 "parameters": entities,
                 "contexts": [],
@@ -49,7 +49,7 @@ class DialogflowEmulator(NoEmulator):
                     "intentName": data["intent"]
                 },
                 "fulfillment": {},
-                "score": None,
+                "score": data["intent"]["confidence"],
             },
             "status": {
                 "code": 200,

--- a/tests/base/test_emulators.py
+++ b/tests/base/test_emulators.py
@@ -126,7 +126,7 @@ def test_dialogflow_response():
         "id": norm["id"],
         "result": {
             "action": data["intent"]["name"],
-            "actionIncomplete": None,
+            "actionIncomplete": False,
             "contexts": [],
             "fulfillment": {},
             "metadata": {

--- a/tests/base/test_emulators.py
+++ b/tests/base/test_emulators.py
@@ -125,16 +125,13 @@ def test_dialogflow_response():
     assert norm == {
         "id": norm["id"],
         "result": {
-            "action": None,
+            "action": data["intent"]["name"],
             "actionIncomplete": None,
             "contexts": [],
             "fulfillment": {},
             "metadata": {
                 "intentId": norm["result"]["metadata"]["intentId"],
-                "intentName": {
-                    "confidence": data["intent"]["confidence"],
-                    "name": data["intent"]["name"]
-                },
+                "intentName": data["intent"]["name"],
                 "webhookUsed": "false"
             },
             "parameters": {
@@ -143,7 +140,7 @@ def test_dialogflow_response():
                 ]
             },
             "resolvedQuery": data["text"],
-            "score": None,
+            "score": data["intent"]["confidence"],
             "source": "agent"
         },
         "sessionId": norm["sessionId"],


### PR DESCRIPTION
**Proposed changes**:
Fixes https://github.com/RasaHQ/rasa_nlu/issues/1484

- Set DialogFlow response key `action` to intent name
- Set DialogFlow response key `score` to intent confidence

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
