### PR TITLE
fix the curl command for the nlu json training

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ a new model
 #### Json format
 ```
 curl 'https://raw.githubusercontent.com/RasaHQ/rasa_nlu/master/sample_configs/config_train_server_json.yml' | \
-curl --request POST --header 'content-type: application/x-yml' -d@- --url 'localhost:5000/train?project=test_model'
+curl --request POST --header 'content-type: application/x-yml' --data-binary @- --url 'localhost:5000/train?project=test_model'
 ```
 
 This will train a simple keyword based models (not usable for anything but this demo). For better


### PR DESCRIPTION
**Problem**:
- https://github.com/RasaHQ/rasa_nlu/issues/1504
- The curl command to train the NLU server based on a http request with a yaml body led to an error 

```json
{
  "error": "while parsing a block mapping\n  in \"<unicode string>\", line 1, column 1:\n    language: \"en\"pipeline: \"spacy_s ... \n    ^\nexpected <block end>, but found '<scalar>'\n  in \"<unicode string>\", line 1, column 15:\n    language: \"en\"pipeline: \"spacy_sklearn\"# data  ... \n                  ^"
}
```
**Proposed changes**:
- use  the `--data-binary` flag as it is done for the curl command in the readme

**Status (please check what you already did)**:
- [x] made PR ready for code review