### PR TITLE
Set random seed for embedding pipeline (default is None)

### DIFF
--- a/docs/components.rst
+++ b/docs/components.rst
@@ -339,6 +339,7 @@ intent_classifier_tensorflow_embedding
             - ``similarity_type`` sets the type of the similarity, it should be either ``cosine`` or ``inner``;
             - ``num_neg`` sets the number of incorrect intent labels, the algorithm will minimize their similarity to the user input during training;
             - ``use_max_sim_neg`` if ``true`` the algorithm only minimizes maximum similarity over incorrect intent labels;
+            - ``random_seed`` (None or int) An integer sets the random seed for numpy and tensorflow, so that the random initialisation is always the same and produces the same training result
         - regularization:
             - ``C2`` sets the scale of L2 regularization
             - ``C_emb`` sets the scale of how important is to minimize the maximum similarity between embeddings of different intent labels;
@@ -368,6 +369,7 @@ intent_classifier_tensorflow_embedding
           "similarity_type": "cosine"  # string 'cosine' or 'inner'
           "num_neg": 20
           "use_max_sim_neg": true  # flag which loss function to use
+          "random_seed": None # set to any int to generate a reproducible training result
           # regularization
           "C2": 0.002
           "C_emb": 0.8

--- a/rasa_nlu/classifiers/embedding_intent_classifier.py
+++ b/rasa_nlu/classifiers/embedding_intent_classifier.py
@@ -92,6 +92,9 @@ class EmbeddingIntentClassifier(Component):
         # flag: if true, only minimize the maximum similarity for
         # incorrect intent labels
         "use_max_sim_neg": True,
+        # set random seed to any int to get reproducible results
+        # try to change to another int if you are not getting good results
+        "random_seed": None,
 
         # regularization parameters
         # the scale of L2 regularization
@@ -168,6 +171,7 @@ class EmbeddingIntentClassifier(Component):
         self.similarity_type = config['similarity_type']
         self.num_neg = config['num_neg']
         self.use_max_sim_neg = config['use_max_sim_neg']
+        self.random_seed = self.component_config['random_seed']
 
     def _load_regularization_params(self, config):
         # type: (Dict[Text, Any]) -> None
@@ -508,6 +512,10 @@ class EmbeddingIntentClassifier(Component):
 
         self.graph = tf.Graph()
         with self.graph.as_default():
+            # set random seed
+            np.random.seed(self.random_seed)
+            tf.set_random_seed(self.random_seed)
+
             self.a_in = tf.placeholder(tf.float32, (None, X.shape[-1]),
                                        name='a')
             self.b_in = tf.placeholder(tf.float32, (None, None, Y.shape[-1]),

--- a/tests/training/test_train.py
+++ b/tests/training/test_train.py
@@ -87,6 +87,32 @@ def test_train_model(pipeline_template, component_builder, tmpdir):
 
 
 @utilities.slowtest
+def test_random_seed(component_builder, tmpdir):
+    '''test if train result is the same for two runs of tf embedding'''
+
+    _config = utilities.base_test_conf("tensorflow_embedding")
+    # set fixed random seed to 1
+    _config.set_component_attr("intent_classifier_tensorflow_embedding", random_seed=1)
+    # first run
+    (trained_a, _, persisted_path_a) = train.do_train(
+            _config,
+            path=tmpdir.strpath + "_a",
+            data=DEFAULT_DATA_PATH,
+            component_builder=component_builder)
+    # second run
+    (trained_b, _, persisted_path_b) = train.do_train(
+            _config,
+            path=tmpdir.strpath + "_b",
+            data=DEFAULT_DATA_PATH,
+            component_builder=component_builder)
+    loaded_a = Interpreter.load(persisted_path_a, component_builder)
+    loaded_b = Interpreter.load(persisted_path_b, component_builder)
+    result_a = loaded_a.parse("hello")["intent"]["confidence"]
+    result_b = loaded_b.parse("hello")["intent"]["confidence"]
+    assert result_a == result_b
+
+
+@utilities.slowtest
 @pytest.mark.parametrize("language, pipeline", pipelines_for_tests())
 def test_train_model_on_test_pipelines(language, pipeline,
                                        component_builder, tmpdir):


### PR DESCRIPTION
Training the Tensorflow Embedding currently gives different results after each run, even if nothing else changed. This can lead to very unstable behavior especially with regards to unseen samples, but also for the training data. For example the user input "ich brauche zahnersatz" yields totally different results after two runs with exactly the same parameters and data. This sample is a part of a slightly longer sample which is in the training data:

rasa_core.processor  - Received user message 'ich brauche zahnersatz' with intent '{'name': 'zahnersatz_zuschuss', 'confidence': 0.909192681312561}' 

rasa_core.processor  - Received user message 'ich brauche zahnersatz' with intent '{'name': 'zahnersatz_zuschuss', 'confidence': 0.6224032044410706}'

The same goes for actual training data like "hi": 
rasa_core.processor  - Received user message 'hi' with intent '{'name': 'greet', 'confidence': 0.9807385206222534}'

rasa_core.processor  - Received user message 'hi' with intent '{'name': 'greet', 'confidence': 0.878046989440918}'

Setting reasonable fallback thresholds (like here at 0.9)  is therefore difficult. Each training run of a production system is a risk. 

This PR changes this and allows to set a stable random seed for Tensorflow and Numpy which can be configured in the pipeline settings. Default is None.

**Proposed changes**:
- added config parameter random_seed to classifier
- added random seed initialization to train method of classifier
- updated changelog
- updated docs
- created test for random seed

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog