### PR TITLE
Bugfix getting config params for custom components from config.yml

### DIFF
--- a/rasa_nlu/config.py
+++ b/rasa_nlu/config.py
@@ -82,9 +82,18 @@ def component_config_from_pipeline(
         defaults=None  # type: Optional[Dict[Text, Any]]
 ):
     # type: (...) -> Dict[Text, Any]
+    from rasa_nlu.registry import registered_components
     for c in pipeline:
-        if c.get("name") == name:
-            return override_defaults(defaults, c)
+        if c.get("name") in registered_components:
+            if c.get("name") == name:
+                return override_defaults(defaults, c)
+        else:
+            # this must be a valid custom component (checked while loading)
+            # custom components have their module path listed as "name"
+            # we therefore have to get their name attribute before comparing
+            custom = utils.class_from_module_path(c.get("name"))
+            if custom.name == name:
+                return override_defaults(defaults, c)
     else:
         return override_defaults(defaults, {})
 


### PR DESCRIPTION
When using custom components, the module path has to be set as the "name" attribute for the component to be loaded. If you try to pass attributes to this custom component in the config.yml it fails, because component_config_from_pipeline() looks for the name attribute of the loaded custom component, which will normally be different from the module path. 

Our current workaround is to set the .name attribute of the custom component to the module path as well and then it works, but this should be fixed.

**Proposed changes**:
- get the name attribute from the module path within component_config_from_pipeline() to make sure custom components can be updated as well

**Status (please check what you already did)**:
- [] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
