### PR TITLE
replace environment variables in config files with actual values #1517

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ This project adheres to `Semantic Versioning`_ starting with version 0.7.0.
 
 Added
 -----
+- environment variables specified with ``${env_variable}`` in a yaml
+  configuration file are now replaced with the value of the environment variable
 
 Changed
 -------

--- a/docs/endpoint_configuration.rst
+++ b/docs/endpoint_configuration.rst
@@ -1,0 +1,36 @@
+:desc: Adding endpoints using an endpoint configuration file
+
+Endpoint Configuration
+======================
+
+To connect NLU to other endpoints, you can specify an endpoint configuration
+within a `YAML <https://en.wikipedia.org/wiki/YAML>`_ file.
+Then run Rasa NLU with the flag
+``--endpoints <path to endpoint configuration.yml``.
+
+For example:
+
+.. code-block:: bash
+
+    python -m rasa_nlu.server \
+        --path <working directory of the server> \
+        --endpoints <path to endpoint configuration>.yml
+
+.. note::
+
+    You can use environment variables within configuration files
+    by specifying them with ``${name of environment variable}``.
+    These placeholders are then replaced by the value of the environment
+    variable.
+
+Model Server
+------------
+
+To use models from a model server, add this to your endpoint configuration:
+
+.. code-block:: yaml
+
+    model:
+        url: <path to your model>
+        token: <authentication token>   # [optional]
+        token_name: <name of the token  # [optional] (default: token)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,6 +72,7 @@ You can see an independent benchmark comparing Rasa NLU to closed source alterna
    http
    python
    persist
+   endpoint_configuration
    docker
 
 .. toctree::

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -143,3 +143,54 @@ def test_endpoint_config():
     assert r.querystring.get("A") == ["B"]
     assert r.querystring.get("P") == ["1"]
     assert r.querystring.get("letoken") == ["mytoken"]
+
+
+def test_environment_variable_not_existing():
+    content = "model: \n  test: ${variable}"
+    with pytest.raises(KeyError):
+        utils.read_yaml(content)
+
+
+def test_environment_variable_dict_without_prefix_and_postfix():
+    os.environ['variable'] = 'test'
+    content = "model: \n  test: ${variable}"
+
+    result = utils.read_yaml(content)
+
+    assert result['model']['test'] == 'test'
+
+
+def test_environment_variable_in_list():
+    os.environ['variable'] = 'test'
+    content = "model: \n  - value\n  - ${variable}"
+
+    result = utils.read_yaml(content)
+
+    assert result['model'][1] == 'test'
+
+
+def test_environment_variable_dict_with_prefix():
+    os.environ['variable'] = 'test'
+    content = "model: \n  test: dir/${variable}"
+
+    result = utils.read_yaml(content)
+
+    assert result['model']['test'] == 'dir/test'
+
+
+def test_environment_variable_dict_with_postfix():
+    os.environ['variable'] = 'test'
+    content = "model: \n  test: ${variable}/dir"
+
+    result = utils.read_yaml(content)
+
+    assert result['model']['test'] == 'test/dir'
+
+
+def test_environment_variable_dict_with_prefix_and_with_postfix():
+    os.environ['variable'] = 'test'
+    content = "model: \n  test: dir/${variable}/dir"
+
+    result = utils.read_yaml(content)
+
+    assert result['model']['test'] == 'dir/test/dir'


### PR DESCRIPTION
**Proposed changes**:
- see issue #1517
- allow specification of environment variables in yaml configuration files.
  - these are specified with `${x}`
  - prefixes and postfixes are picked up, e.g. `dir/${x}/another` with `x=path` becomes `dir/path/another`

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] update documentation
- [x] updated the changelog
