### PR TITLE
use cloudpickle==0.6.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Changed
   config parameters as well as comments and types for all class functions.
 - the http server's ``POST /evaluate`` endpoint returns evaluation results
   for both entities and intents
+- use cloudpickle version 0.6.1
 
 Removed
 -------

--- a/alt_requirements/requirements_bare.txt
+++ b/alt_requirements/requirements_bare.txt
@@ -10,7 +10,7 @@ requests==2.20.0
 tqdm==4.19.5
 numpy==1.14.5
 simplejson==3.13.2
-cloudpickle==0.5.2
+cloudpickle==0.6.1
 msgpack-python==0.5.4
 packaging==17.1
 pyyaml==3.12


### PR DESCRIPTION
**Proposed changes**:
- fixes https://github.com/RasaHQ/rasa_nlu/issues/1514
- increment cloudpickle to use the latest release

**Testing**
- You can test this running the container on gcloud. Before the pr it failed before with the error from the issue. 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] updated the changelog
