### PR TITLE
Missing dependency for TensorFlow

### DIFF
--- a/alt_requirements/requirements_tensorflow_sklearn.txt
+++ b/alt_requirements/requirements_tensorflow_sklearn.txt
@@ -3,4 +3,5 @@
 
 scikit-learn==0.19.1
 tensorflow==1.10.0
+scipy==1.1.0
 sklearn-crfsuite==0.3.6


### PR DESCRIPTION
**Proposed changes**:
- According to [Issue #1315](https://github.com/RasaHQ/rasa_nlu/issues/1315), the lack of `scipy` in requirements list might cause a fail at training with TensorFlow.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog