### PR TITLE
handle emojis when running as server

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Changed
 - the http server's ``POST /evaluate`` endpoint returns evaluation results
   for both entities and intents
 - use cloudpickle version 0.6.1
+- replaced ``yaml`` with ``ruamel.yaml``
 
 Removed
 -------
@@ -30,6 +31,7 @@ Fixed
 -----
 - Should loading jieba custom dictionaries only once.
 - Set attributes of custom components correctly if they defer from the default
+- NLU Server can now handle training data mit emojis in it
 
 [0.13.7] - 2018-10-11
 ^^^^^^^^^^^^^^^^^^^^^

--- a/alt_requirements/requirements_bare.txt
+++ b/alt_requirements/requirements_bare.txt
@@ -13,5 +13,5 @@ simplejson==3.13.2
 cloudpickle==0.6.1
 msgpack-python==0.5.4
 packaging==17.1
-pyyaml==3.12
+ruamel.yaml==0.15.78
 coloredlogs==9.0

--- a/data/examples/rasa/demo-rasa.json
+++ b/data/examples/rasa/demo-rasa.json
@@ -22,12 +22,12 @@
     ],
     "common_examples": [
       {
-        "text": "hey", 
+        "text": "hey",
         "intent": "greet", 
         "entities": []
       }, 
       {
-        "text": "howdy", 
+        "text": "howdy",
         "intent": "greet", 
         "entities": []
       }, 

--- a/rasa_nlu/config.py
+++ b/rasa_nlu/config.py
@@ -8,7 +8,7 @@ import logging
 import os
 
 import six
-import yaml
+import ruamel.yaml as yaml
 from builtins import object
 # Describes where to search for the config file if no location is specified
 from typing import Text, Optional, Dict, Any, List

--- a/rasa_nlu/utils/__init__.py
+++ b/rasa_nlu/utils/__init__.py
@@ -20,9 +20,23 @@ import requests
 import simplejson
 import six
 import yaml
+import yaml.reader
 from builtins import str
 from future.utils import PY3
 from requests.auth import HTTPBasicAuth
+
+
+if PY3:
+    yaml.reader.Reader.NON_PRINTABLE = re.compile(
+        u'[^\x09\x0A\x0D\x20-\x7E\x85\xA0-\uD7FF\uE000-\uFFFD\U00010000-'
+        u'\U0010FFFF]')
+else:
+    # to make this compatible with narrow builds use fix
+    # from https://stackoverflow.com/a/31605097/3429596
+    yaml.reader.Reader.NON_PRINTABLE = re.compile(
+        u'/(?:[\0-\x08\x0B\f\x0E-\x1F\x7F-\x84\x86-\x9F\uFFFE\uFFFF]|'
+        u'[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|'
+        u'(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])/')
 
 
 def add_logging_option_arguments(parser, default=logging.WARNING):

--- a/rasa_nlu/utils/__init__.py
+++ b/rasa_nlu/utils/__init__.py
@@ -358,7 +358,7 @@ def create_temporary_file(data, suffix="", mode="w+"):
 
     if PY3:
         f = tempfile.NamedTemporaryFile(mode=mode, suffix=suffix,
-                                        delete=False)
+                                        delete=False, encoding="utf-8")
         f.write(data)
     else:
         f = tempfile.NamedTemporaryFile("w+", suffix=suffix,

--- a/rasa_nlu/utils/__init__.py
+++ b/rasa_nlu/utils/__init__.py
@@ -251,7 +251,7 @@ def read_yaml(content):
     replace_environment_variables()
 
     yaml_parser = yaml.YAML(typ="safe")
-    yaml_parser.version = "1.1"
+    yaml_parser.version = "1.2"
     yaml_parser.unicode_supplementary = True
 
     return yaml_parser.load(content)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ install_requires = [
     "matplotlib~=2.0",
     "numpy>=1.13",
     "simplejson",
-    "pyyaml",
+    "ruamel.yaml~=0.15",
     'coloredlogs',
 ]
 

--- a/tests/base/test_server.py
+++ b/tests/base/test_server.py
@@ -10,7 +10,7 @@ import tempfile
 
 import pytest
 import time
-import yaml
+import ruamel.yaml as yaml
 from treq.testing import StubTreq
 
 from rasa_nlu.data_router import DataRouter

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -196,14 +197,28 @@ def test_environment_variable_dict_with_prefix_and_with_postfix():
     assert result['model']['test'] == 'dir/test/dir'
 
 
+def test_emojis_in_yaml():
+    test_data = """
+    data:
+        - one 😁
+        - two £
+    """
+    actual = utils.read_yaml(test_data)
+
+    assert actual["data"][0] == "one 😁"
+    assert actual["data"][1] == "two £"
+
+
 def test_emojis_in_tmp_file():
     test_data = """
         data:
             - one 😁
+            - two £
         """
     test_file = utils.create_temporary_file(test_data)
-    with io.open(test_file, mode='r', encoding="utf-8") as file:
-        content = file.read()
+    with io.open(test_file, mode='r', encoding="utf-8") as f:
+        content = f.read()
     actual = utils.read_yaml(content)
 
     assert actual["data"][0] == "one 😁"
+    assert actual["data"][1] == "two £"

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -194,3 +194,16 @@ def test_environment_variable_dict_with_prefix_and_with_postfix():
     result = utils.read_yaml(content)
 
     assert result['model']['test'] == 'dir/test/dir'
+
+
+def test_emojis_in_tmp_file():
+    test_data = """
+        data:
+            - one 😁
+        """
+    test_file = utils.create_temporary_file(test_data)
+    with io.open(test_file, mode='r', encoding="utf-8") as file:
+        content = file.read()
+    actual = utils.read_yaml(content)
+
+    assert actual["data"][0] == "one 😁"

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -222,3 +222,17 @@ def test_emojis_in_tmp_file():
 
     assert actual["data"][0] == "one 😁"
     assert actual["data"][1] == "two £"
+
+
+def test_bool_str():
+    test_data = """
+    one: "yes"
+    two: "true"
+    three: "True"
+    """
+
+    actual = utils.read_yaml(test_data)
+
+    assert actual["one"] == "yes"
+    assert actual["two"] == "true"
+    assert actual["three"] == "True"

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import tempfile
 
 import pytest
-import yaml
+import ruamel.yaml as yaml
 from builtins import object
 
 from rasa_nlu.config import RasaNLUModelConfig


### PR DESCRIPTION
**Proposed changes**:
- replace `pyaml` with `ruamel.yaml` since it is 
  * better supported
  * handles emojis in yamls out of the box
- provide encoding for the created tmp file


**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- ~[ ] updated the documentation~
- [x] updated the changelog
