### PR TITLE
EmbeddingIntentClassifier: allow config overwrite

### DIFF
--- a/rasa_nlu/classifiers/embedding_intent_classifier.py
+++ b/rasa_nlu/classifiers/embedding_intent_classifier.py
@@ -136,8 +136,6 @@ class EmbeddingIntentClassifier(Component):
         self._check_tensorflow()
         super(EmbeddingIntentClassifier, self).__init__(component_config)
 
-        self._load_params(self.component_config)
-
         # transform numbers to intents
         self.inv_intent_dict = inv_intent_dict
         # encode all intents with numbers
@@ -157,10 +155,6 @@ class EmbeddingIntentClassifier(Component):
     # init helpers
     def _load_nn_architecture_params(self, config):
         # type: (Dict[Text, Any]) -> None
-        self.hidden_layer_sizes = {'a': config['hidden_layers_sizes_a'],
-                                   'b': config['hidden_layers_sizes_b']}
-
-        self.batch_size = config['batch_size']
         self.epochs = config['epochs']
 
     def _load_embedding_params(self, config):
@@ -401,15 +395,16 @@ class EmbeddingIntentClassifier(Component):
         # type: (int) -> int
         """Linearly increase batch size with every epoch.
             The idea comes from https://arxiv.org/abs/1711.00489"""
-        if not isinstance(self.batch_size, list):
-            return int(self.batch_size)
+        batch_size = config['batch_size']
+        if not isinstance(batch_size, list):
+            return int(batch_size)
 
         if self.epochs > 1:
-            return int(self.batch_size[0] +
-                       epoch * (self.batch_size[1] -
-                                self.batch_size[0]) / (self.epochs - 1))
+            return int(batch_size[0] +
+                       epoch * (batch_size[1] -
+                                batch_size[0]) / (self.epochs - 1))
         else:
-            return int(self.batch_size[0])
+            return int(batch_size[0])
 
     # noinspection PyPep8Naming
     def _train_tf(self,

--- a/rasa_nlu/classifiers/embedding_intent_classifier.py
+++ b/rasa_nlu/classifiers/embedding_intent_classifier.py
@@ -155,7 +155,7 @@ class EmbeddingIntentClassifier(Component):
         self.intent_embed = intent_embed
 
     def _load_params(self):
-        # type: (Dict[Text, Any]) -> None
+        # type: () -> None
         self.num_neg = self.component_config['num_neg']
         
         self.intent_tokenization_flag = self.component_config['intent_tokenization_flag']

--- a/rasa_nlu/classifiers/embedding_intent_classifier.py
+++ b/rasa_nlu/classifiers/embedding_intent_classifier.py
@@ -136,7 +136,7 @@ class EmbeddingIntentClassifier(Component):
         self._check_tensorflow()
         super(EmbeddingIntentClassifier, self).__init__(component_config)
 
-        self._load_params()
+        self._load_params(self.component_config)
 
         # transform numbers to intents
         self.inv_intent_dict = inv_intent_dict
@@ -321,10 +321,10 @@ class EmbeddingIntentClassifier(Component):
         """Create tf graph for training"""
 
         emb_a = self._create_tf_embed_nn(a_in, is_training,
-                                         self.hidden_layer_sizes['a'],
+                                         self.component_config['hidden_layers_sizes_a'],
                                          name='a')
         emb_b = self._create_tf_embed_nn(b_in, is_training,
-                                         self.hidden_layer_sizes['b'],
+                                         self.component_config['hidden_layers_sizes_b'],
                                          name='b')
         return emb_a, emb_b
 

--- a/rasa_nlu/classifiers/embedding_intent_classifier.py
+++ b/rasa_nlu/classifiers/embedding_intent_classifier.py
@@ -157,7 +157,7 @@ class EmbeddingIntentClassifier(Component):
     def _load_params(self):
         # type: () -> None
         self.num_neg = self.component_config['num_neg']
-        
+
         self.intent_tokenization_flag = self.component_config['intent_tokenization_flag']
         if self.intent_tokenization_flag and not self.component_config['intent_split_symbol']:
             logger.warning("intent_split_symbol was not specified, "
@@ -261,7 +261,11 @@ class EmbeddingIntentClassifier(Component):
                                 activation=tf.nn.relu,
                                 kernel_regularizer=reg,
                                 name='hidden_layer_{}_{}'.format(name, i))
-            x = tf.layers.dropout(x, rate=self.component_config['droprate'], training=is_training)
+            x = tf.layers.dropout(
+                x,
+                rate=self.component_config['droprate'],
+                training=is_training
+            )
 
         x = tf.layers.dense(inputs=x,
                             units=self.component_config['embed_dim'],
@@ -292,7 +296,7 @@ class EmbeddingIntentClassifier(Component):
             sim_emb: between individual embedded intent labels only"""
 
         similarity_type = self.component_config['similarity_type']
-        
+
         if similarity_type == 'cosine':
             # normalize embedding vectors for cosine similarity
             a = tf.nn.l2_normalize(a, -1)


### PR DESCRIPTION
**Previous problem**:
Setting `epochs` for training via the `config.yml` was not possible.

**Proposed changes**:
This PR refactors the use of config parameters in `EmbeddingIntentClassifier` and allows to use the component config (e.g. via `config.yml`). The previous `_load_params` implementation seemed quite doubled, as the superclass already does the logic of merging the config with the defaults. Also doubling all settings as direct attributes seemed superfluous to me. Therefore all usages of them are refactored to use `self.component_config`. The only exceptions and notable occurances are:
* `self.num_neg`
  This is updated during training. Not sure of a variable in `train` would be fine, I sticked to the safe version and kept it as an attribute.
* `self.intent_tokenization_flag`
  To keep the early warning message I kept this in `_load_params`.
* `evaluate_every_num_epochs`
  The logic moved from `_load_visual_params` directly to `_train_tf`, as no side-effects happen.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] ~~added some tests for the functionality~~
- [ ] ~~updated the documentation~~
- [ ] ~~updated the changelog~~
