### PR TITLE
Increase scikit-learn version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Changed
 - replaced ``yaml`` with ``ruamel.yaml``
 - updated spacy version to 2.0.18
 - updated TensorFlow version to 1.12.0
+- updated scikit-learn version to 0.20.2
 
 Removed
 -------
@@ -44,6 +45,7 @@ Fixed
 - Updated CORS support for the server.
   Added the ``Access-Control-Allow-Headers`` and ``Content-Type`` headers for nlu server
 - parsing of emojis which are sent within jsons
+- Bad input shape error from ``sklearn_intent_classifier`` when using ``scikit-learn==0.20.2``
 
 [0.13.8] - 2018-11-21
 ^^^^^^^^^^^^^^^^^^^^^

--- a/alt_requirements/requirements_spacy_sklearn.txt
+++ b/alt_requirements/requirements_spacy_sklearn.txt
@@ -2,6 +2,6 @@
 -r requirements_bare.txt
 
 spacy==2.0.18
-scikit-learn==0.19.1
+scikit-learn==0.20.2
 scipy==1.1.0
 sklearn-crfsuite==0.3.6

--- a/alt_requirements/requirements_tensorflow_sklearn.txt
+++ b/alt_requirements/requirements_tensorflow_sklearn.txt
@@ -1,7 +1,7 @@
 # Minimum Install Requirements
 -r requirements_bare.txt
 
-scikit-learn==0.19.1
+scikit-learn==0.20.2
 tensorflow==1.12.0
 scipy==1.1.0
 sklearn-crfsuite==0.3.6

--- a/rasa_nlu/classifiers/sklearn_intent_classifier.py
+++ b/rasa_nlu/classifiers/sklearn_intent_classifier.py
@@ -178,10 +178,10 @@ class SklearnIntentClassifier(Component):
         else:
             X = message.get("text_features").reshape(1, -1)
             intent_ids, probabilities = self.predict(X)
-            intents = self.transform_labels_num2str(intent_ids.T)
+            intents = self.transform_labels_num2str(np.ravel(intent_ids))
             # `predict` returns a matrix as it is supposed
             # to work for multiple examples as well, hence we need to flatten
-            intents, probabilities = intents.flatten(), probabilities.flatten()
+            probabilities = probabilities.flatten()
 
             if intents.size > 0 and probabilities.size > 0:
                 ranking = list(zip(list(intents),

--- a/rasa_nlu/classifiers/sklearn_intent_classifier.py
+++ b/rasa_nlu/classifiers/sklearn_intent_classifier.py
@@ -178,7 +178,7 @@ class SklearnIntentClassifier(Component):
         else:
             X = message.get("text_features").reshape(1, -1)
             intent_ids, probabilities = self.predict(X)
-            intents = self.transform_labels_num2str(intent_ids)
+            intents = self.transform_labels_num2str(intent_ids.T)
             # `predict` returns a matrix as it is supposed
             # to work for multiple examples as well, hence we need to flatten
             intents, probabilities = intents.flatten(), probabilities.flatten()

--- a/setup.py
+++ b/setup.py
@@ -44,12 +44,12 @@ install_requires = [
 
 extras_requires = {
     'test': tests_requires,
-    'spacy': ["scikit-learn<0.20",
+    'spacy': ["scikit-learn~=0.20.2",
               "sklearn-crfsuite~=0.3.6",
               "scipy~=1.1",
               "spacy<=2.0.18,>2.0",
               ],
-    'tensorflow': ["scikit-learn<0.20",
+    'tensorflow': ["scikit-learn~=0.20.2",
                    "sklearn-crfsuite~=0.3.6",
                    "scipy~=1.1",
                    "tensorflow~=1.12"


### PR DESCRIPTION
`scikit-learn==0.20.2` has a nice `output_dict` feature we can use in our evaluate script, but it was causing [errors with our classifier](https://github.com/RasaHQ/rasa_nlu/issues/1600)

**Proposed changes**:
- Transpose `intent_ids` vector
- Pin `scikit-learn==0.20.2`

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] updated the changelog
