### PR TITLE
Uses Spacy 2 syntax to disable dependency parser

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Added
 
 Changed
 -------
+- applied spacy guidelines on how to disable pipeline components
 
 Removed
 -------

--- a/rasa_nlu/utils/spacy_utils.py
+++ b/rasa_nlu/utils/spacy_utils.py
@@ -59,7 +59,7 @@ class SpacyNLP(Component):
         logger.info("Trying to load spacy model with "
                     "name '{}'".format(spacy_model_name))
 
-        nlp = spacy.load(spacy_model_name, parser=False)
+        nlp = spacy.load(spacy_model_name, disable=['parser'])
         cls.ensure_proper_language_model(nlp)
         return SpacyNLP(component_conf, nlp)
 
@@ -109,7 +109,7 @@ class SpacyNLP(Component):
         component_meta = model_metadata.for_component(cls.name)
         model_name = component_meta.get("model")
 
-        nlp = spacy.load(model_name, parser=False)
+        nlp = spacy.load(model_name, disable=['parser'])
         cls.ensure_proper_language_model(nlp)
         return cls(component_meta, nlp)
 


### PR DESCRIPTION
Closes #1649

Use Spacy 2 syntax to disable dependency parser

See the note "Uses Spacy 2 syntax to disable dependency parser" in https://spacy.io/usage/processing-pipelines#disabling