### PR TITLE
Fixes warning of inconsistent entity synonyms

### DIFF
--- a/rasa_nlu/training_data/util.py
+++ b/rasa_nlu/training_data/util.py
@@ -18,6 +18,6 @@ def transform_entity_synonyms(synonyms, known_synonyms=None):
 def check_duplicate_synonym(entity_synonyms, text, syn, context_str=""):
     if text in entity_synonyms and entity_synonyms[text] != syn:
         logger.warning("Found inconsistent entity synonyms while {0}, "
-                       "overwriting {1}->{2}"
-                       "with {1}->{2} during merge"
+                       "overwriting {1}->{2} "
+                       "with {1}->{3} during merge"
                        "".format(context_str, text, entity_synonyms[text], syn))


### PR DESCRIPTION
**Proposed changes**:
There was a small formatting error in the error message in case of inconsistent synonyms (the overwritten synonym was displayed instead of the replacement). Additionally, I added a space before with.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- ~~added some tests for the functionality~~
- ~~updated the documentation~~
- [ ] updated the changelog