### PR TITLE
Update CHANGELOG.rst

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,7 @@ Removed
 Fixed
 -----
 
-[0.14.3] - 2018-02-01
+[0.14.3] - 2019-02-01
 ^^^^^^^^^^^^^^^^^^^^^
 
 Changed
@@ -34,7 +34,7 @@ Changed
   and only on branches ending in ``.x`` (i.e. new version releases)
 - pinned ``coloredlogs``, ``future`` and ``packaging``
 
-[0.14.2] - 2018-01-29
+[0.14.2] - 2019-01-29
 ^^^^^^^^^^^^^^^^^^^^^
 
 Added
@@ -47,7 +47,7 @@ Changed
 - updated requirements to match Core and SDK
 - pinned keras dependecies
 
-[0.14.1] - 2018-01-23
+[0.14.1] - 2019-01-23
 ^^^^^^^^^^^^^^^^^^^^^
 
 Fixed
@@ -56,7 +56,7 @@ Fixed
 
 .. _v0-14-0:
 
-[0.14.0] - 2018-01-23
+[0.14.0] - 2019-01-23
 ^^^^^^^^^^^^^^^^^^^^^
 
 Added


### PR DESCRIPTION
Release dates from 14.0 onwards had the date 2018 instead of 2019. Changes that.

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
