### PR TITLE
Process lookup table when transforming Dialogflow Data

### DIFF
--- a/rasa_nlu/training_data/formats/dialogflow.py
+++ b/rasa_nlu/training_data/formats/dialogflow.py
@@ -92,11 +92,11 @@ class DialogflowReader(TrainingDataReader):
     @staticmethod
     def _extract_lookup_tables(name, examples):
         """Extract the lookup table from the entity synonyms"""
-        lookup_tables = []
         synonyms = [e["synonyms"] for e in examples if "synonyms" in e]
         synonyms = DialogflowReader._flatten(synonyms)
         elements = [synonym for synonym in synonyms if "@" not in synonym]
-        if len(lookup_tables) == 0:
+
+        if len(elements) == 0:
             return False
         return [{
             'name': name,

--- a/rasa_nlu/training_data/formats/dialogflow.py
+++ b/rasa_nlu/training_data/formats/dialogflow.py
@@ -42,7 +42,7 @@ class DialogflowReader(TrainingDataReader):
         elif fformat == DIALOGFLOW_INTENT:
             return self._read_intent(root_js, examples_js)
         elif fformat == DIALOGFLOW_ENTITIES:
-            return self._read_entities(examples_js)
+            return self._read_entities(root_js, examples_js)
 
     def _read_intent(self, intent_js, examples_js):
         """Reads the intent and examples from respective jsons."""
@@ -86,11 +86,33 @@ class DialogflowReader(TrainingDataReader):
         return entity
 
     @staticmethod
-    def _read_entities(examples_js):
+    def _flatten(list_of_lists):
+        return [item for items in list_of_lists for item in items]
+
+    @staticmethod
+    def _extract_lookup_tables(name, examples):
+        """Extract the lookup table from the entity synonyms"""
+        lookup_tables = []
+        synonyms = [e["synonyms"] for e in examples if "synonyms" in e]
+        synonyms = DialogflowReader._flatten(synonyms)
+        elements = [synonym for synonym in synonyms if "@" not in synonym]
+        if len(lookup_tables) == 0:
+            return False
+        return [{
+            'name': name,
+            'elements': elements
+        }]
+
+    @staticmethod
+    def _read_entities(entity_js, examples_js):
         from rasa_nlu.training_data import TrainingData
 
         entity_synonyms = transform_entity_synonyms(examples_js)
-        return TrainingData([], entity_synonyms)
+
+        name = entity_js.get("name")
+        lookup_tables = DialogflowReader._extract_lookup_tables(name,
+                                                                examples_js)
+        return TrainingData([], entity_synonyms, [], lookup_tables)
 
     @staticmethod
     def _read_examples_js(fn, language, fformat):

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -61,6 +61,8 @@ def test_dialogflow_data():
     assert len(td.entity_examples) == 5
     assert len(td.intent_examples) == 24
     assert len(td.training_examples) == 24
+    assert len(td.lookup_tables) == 2
+
     assert td.intents == {"affirm", "goodbye", "hi", "inform"}
     assert td.entities == {"cuisine", "location"}
     non_trivial_synonyms = {k: v
@@ -68,6 +70,10 @@ def test_dialogflow_data():
     assert non_trivial_synonyms == {"mexico": "mexican",
                                     "china": "chinese",
                                     "india": "indian"}
+    assert td.lookup_tables[0]['name'] == 'location'
+    assert len(td.lookup_tables[0]['elements']) == 4
+    assert td.lookup_tables[1]['name'] == 'cuisine'
+    assert len(td.lookup_tables[1]['elements']) == 6
 
 
 def test_lookup_table_json():

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -75,6 +75,7 @@ def test_dialogflow_data():
     assert{len(td.lookup_tables[0]['elements']),
             len(td.lookup_tables[1]['elements'])} == {4, 6}
 
+
 def test_lookup_table_json():
     lookup_fname = 'data/test/lookup_tables/plates.txt'
     td_lookup = training_data.load_data(

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -73,7 +73,7 @@ def test_dialogflow_data():
     assert {td.lookup_tables[0]['name'],
             td.lookup_tables[1]['name']} == {'location', 'cuisine'}
     assert{len(td.lookup_tables[0]['elements']),
-            len(td.lookup_tables[1]['elements'])} == {4,6}
+            len(td.lookup_tables[1]['elements'])} == {4, 6}
 
 def test_lookup_table_json():
     lookup_fname = 'data/test/lookup_tables/plates.txt'

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -72,7 +72,7 @@ def test_dialogflow_data():
     # The order changes based on different computers hence the grouping
     assert {td.lookup_tables[0]['name'],
             td.lookup_tables[1]['name']} == {'location', 'cuisine'}
-    assert{len(td.lookup_tables[0]['elements']),
+    assert {len(td.lookup_tables[0]['elements']),
             len(td.lookup_tables[1]['elements'])} == {4, 6}
 
 

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -62,7 +62,6 @@ def test_dialogflow_data():
     assert len(td.intent_examples) == 24
     assert len(td.training_examples) == 24
     assert len(td.lookup_tables) == 2
-
     assert td.intents == {"affirm", "goodbye", "hi", "inform"}
     assert td.entities == {"cuisine", "location"}
     non_trivial_synonyms = {k: v

--- a/tests/base/test_training_data.py
+++ b/tests/base/test_training_data.py
@@ -69,11 +69,11 @@ def test_dialogflow_data():
     assert non_trivial_synonyms == {"mexico": "mexican",
                                     "china": "chinese",
                                     "india": "indian"}
-    assert td.lookup_tables[0]['name'] == 'location'
-    assert len(td.lookup_tables[0]['elements']) == 4
-    assert td.lookup_tables[1]['name'] == 'cuisine'
-    assert len(td.lookup_tables[1]['elements']) == 6
-
+    # The order changes based on different computers hence the grouping
+    assert {td.lookup_tables[0]['name'],
+            td.lookup_tables[1]['name']} == {'location', 'cuisine'}
+    assert{len(td.lookup_tables[0]['elements']),
+            len(td.lookup_tables[1]['elements'])} == {4,6}
 
 def test_lookup_table_json():
     lookup_fname = 'data/test/lookup_tables/plates.txt'


### PR DESCRIPTION
**Proposed changes**:
- When using RASA with Dialogflow input data format, you don't get the added benefits of lookup tables as it is not added during the format transformation. This PR adds the lookup table from the entity examples

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
