### PR TITLE
fix travis build timeout error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ install:
   - python -m spacy link en_core_web_md en
   - pip install https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-2.0.0/de_core_news_sm-2.0.0.tar.gz --no-cache-dir > jnk
   - python -m spacy link de_core_news_sm de
-  - if [[ ! -f /tmp/cached/total_word_feature_extractor.dat ]]; then wget --quiet -P /tmp/cached/ https://s3-eu-west-1.amazonaws.com/mitie/total_word_feature_extractor.dat;
+  - if [[ ! -f /tmp/cached/total_word_feature_extractor.dat ]]; then 
+    travis_wait wget --quiet -P /tmp/cached/ https://s3-eu-west-1.amazonaws.com/mitie/total_word_feature_extractor.dat;
     fi
   - mv /tmp/cached/total_word_feature_extractor.dat data/total_word_feature_extractor.dat
   - pip list


### PR DESCRIPTION
**Proposed changes**:
Many of the past travis tests failed because this download:
```
wget --quiet -P /tmp/cached/ https://s3-eu-west-1.amazonaws.com/mitie/total_word_feature_extractor.dat
```
took longer than the standard 10 minute timeout. 

This PR precedes it with the travis_wait function which doubles the timout to 20 minutes according to the [docs](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received).

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
