### PR TITLE
split do_extarctor_overlap to correctly handle overllappine entities

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Removed
 
 Fixed
 -----
+- Overlapping entities cause an exception only if the extractor does not support them.
 
 [0.14.3] - 2019-02-01
 ^^^^^^^^^^^^^^^^^^^^^

--- a/rasa_nlu/evaluate.py
+++ b/rasa_nlu/evaluate.py
@@ -532,9 +532,6 @@ def determine_true_token_labels(token, entities):
     if len(entities) == 0:
         return "O"
 
-    if do_entities_overlap(entities):
-        raise ValueError("The possible entities should not overlap")
-
     candidates = find_intersecting_entites(token, entities)
     return pick_best_entity_fit(token, candidates)
 

--- a/rasa_nlu/server.py
+++ b/rasa_nlu/server.py
@@ -1,7 +1,8 @@
 import argparse
 import logging
-import simplejson
 from functools import wraps
+
+import simplejson
 from klein import Klein
 from twisted.internet import reactor, threads
 from twisted.internet.defer import inlineCallbacks, returnValue

--- a/tests/base/test_evaluation.py
+++ b/tests/base/test_evaluation.py
@@ -16,6 +16,7 @@ from rasa_nlu.evaluate import does_token_cross_borders
 from rasa_nlu.evaluate import align_entity_predictions
 from rasa_nlu.evaluate import determine_intersection
 from rasa_nlu.evaluate import determine_token_labels
+from rasa_nlu.evaluate import determine_true_token_labels
 from rasa_nlu.config import RasaNLUModelConfig
 from rasa_nlu.tokenizers import Token
 from rasa_nlu import utils
@@ -170,12 +171,12 @@ def test_determine_token_labels_throws_error():
     with pytest.raises(ValueError):
         determine_token_labels(CH_correct_segmentation,
                                [CH_correct_entity,
-                                CH_wrong_entity], ["ner_crf"])
+                                CH_wrong_entity], ["A", "B", "ner_crf"])
 
 
 def test_determine_token_labels_no_extractors():
-    determine_token_labels(CH_correct_segmentation[0],
-                           [CH_correct_entity, CH_wrong_entity], None)
+    determine_true_token_labels(CH_correct_segmentation[0],
+                                [CH_correct_entity, CH_wrong_entity])
 
 
 def test_determine_token_labels_with_extractors():
@@ -259,7 +260,6 @@ def test_run_cv_evaluation():
 
 
 def test_intent_evaluation_report(tmpdir_factory):
-
     path = tmpdir_factory.mktemp("evaluation").strpath
     report_folder = os.path.join(path, "reports")
     report_filename = os.path.join(report_folder, "intent_report.json")
@@ -297,7 +297,6 @@ def test_intent_evaluation_report(tmpdir_factory):
 
 
 def test_entity_evaluation_report(tmpdir_factory):
-
     path = tmpdir_factory.mktemp("evaluation").strpath
     report_folder = os.path.join(path, "reports")
 


### PR DESCRIPTION
**Proposed changes**:
- split determine_token_labels in two functions, determin_token_labels and determine_true_token_labels. This should handle correctly overlapping entities, and throw an exception only if overlapping entities are found and a extractor that does not support them is used.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
