### PR TITLE
removed unnecessary import

### DIFF
--- a/rasa_nlu/classifiers/mitie_intent_classifier.py
+++ b/rasa_nlu/classifiers/mitie_intent_classifier.py
@@ -99,7 +99,6 @@ class MitieIntentClassifier(Component):
     def persist(self,
                 file_name: Text,
                 model_dir: Text) -> Dict[Text, Any]:
-        import os
 
         if self.clf:
             file_name = file_name + ".dat"


### PR DESCRIPTION
I wonder if the `import mitie` should perhaps also just happen in the beginning.
Currently it is imported at the beginning of the module only `if typing.TYPE_CHECKING` but then it is imported in two different methods.

**Status (please check what you already did)**:
- [x] made PR ready for code review
