### PR TITLE
Issue #1781.  Resolving UnicodeError for Windows and Lookup Tables via file method

### DIFF
--- a/rasa_nlu/featurizers/regex_featurizer.py
+++ b/rasa_nlu/featurizers/regex_featurizer.py
@@ -102,7 +102,7 @@ class RegexFeaturizer(Featurizer):
         else:
 
             try:
-                f = io.open(lookup_elements, 'r')
+                f = io.open(lookup_elements, 'r', encoding='utf-8')
             except IOError:
                 raise ValueError("Could not load lookup table {}"
                                  "Make sure you've provided the correct path"


### PR DESCRIPTION
Windows defaults to using cp1252 for open.  This creates a UnicodeError potentially when trying to

use files for Lookup Tables (list method still works in Windows).  Apply this fix such that the encoding is
explicitly utf-8 (as it is in other places in the repository).

**Proposed changes**:
- Change the open statement to use encoding='utf-8' as to do other open statements throughout the project.
- fixes #1781 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
