### PR TITLE
fix tf requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras_requires = {
               ],
     'tensorflow': ["sklearn-crfsuite~=0.3.6",
                    "scipy~=1.1",
-                   "tensorflow~=1.12",
+                   "tensorflow~=1.12.0",
                    "keras-applications==1.0.6",
                    "keras-preprocessing==1.0.5"
                    ],


### PR DESCRIPTION
tf 1.13.* satisfies the current requirement:
```
Requirement already satisfied: tensorflow~=1.12; extra == "tensorflow" in /Users/erohmensing/anaconda3/envs/demobot/lib/python3.6/site-packages (from rasa_nlu[tensorflow]~=0.14.4->rasa-demo==1.1) (1.13.1)
```
but that isn't compatible with core:
```
rasa-core 0.13.4 has requirement tensorflow~=1.12.0, but you'll have tensorflow 1.13.1 which is incompatible.
```

this will match the core requirement and require that the version be 1.12.*