### PR TITLE
merge 0.14.x into master

### DIFF
--- a/rasa_nlu/version.py
+++ b/rasa_nlu/version.py
@@ -3,4 +3,4 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-__version__ = '0.14.5'
+__version__ = '0.14.6'


### PR DESCRIPTION
merged PR #1787 on 0.14.x because the pip download requirements were allowing users to keep tensorflow `1.13.*` when we only support `1.12.*`. This may be moot on master if by the next major release we switch to tf `1.13.1` to support python 3.7 (#1709) though.
