### PR TITLE
FallbackPolicy: Log if core threshold is used as confidence

### DIFF
--- a/rasa/core/policies/fallback.py
+++ b/rasa/core/policies/fallback.py
@@ -112,9 +112,9 @@ class FallbackPolicy(Policy):
             # predict fallback action with confidence `core_threshold`
             # if this is the highest confidence in the ensemble,
             # the fallback action will be executed.
-            logger.debug("Predict fallback action with confidence "
-                         "'core_threshold' ({}). "
-                         "".format(self.core_threshold))
+            logger.debug("NLU confidence threshold met, confidence of "
+                         "fallback action set to core threshold ({})."
+                         .format(self.core_threshold))
             result = self.fallback_scores(domain, self.core_threshold)
 
         return result

--- a/rasa/core/policies/fallback.py
+++ b/rasa/core/policies/fallback.py
@@ -112,6 +112,9 @@ class FallbackPolicy(Policy):
             # predict fallback action with confidence `core_threshold`
             # if this is the highest confidence in the ensemble,
             # the fallback action will be executed.
+            logger.debug("Predict fallback action with confidence "
+                         "'core_threshold' ({}). "
+                         "".format(self.core_threshold))
             result = self.fallback_scores(domain, self.core_threshold)
 
         return result


### PR DESCRIPTION
**Proposed changes**:
- Log a message in the `FallbackPolicy` when the `core_threshold` is used as confidence. In case the FallbackPolicy was chosen in the end, the user knows from the log message before, that there was no other action policy that had a higher confidence than the `core_threshold`.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
