### PR TITLE
emulate form rejection in evaluation

### DIFF
--- a/examples/concertbot/Makefile
+++ b/examples/concertbot/Makefile
@@ -20,7 +20,7 @@ run-core:
 	python -m rasa.core.run --core models/dialogue --endpoints endpoints.yml
 
 run-actions:
-	python -m rasa.core_sdk.endpoint --actions actions
+	python -m rasa_core_sdk.endpoint --actions actions
 
 train-core:
 	python train.py

--- a/examples/formbot/Makefile
+++ b/examples/formbot/Makefile
@@ -15,7 +15,7 @@ train-core:
 	python -m rasa.core.train -s data/stories.md -d domain.yml -o models/dialogue --debug
 
 run-core:
-	python -m rasa.core.run --core models/dialogue --verbose --endpoints endpoints.yml
+	python -m rasa.core.run --core models/dialogue --nlu models/nlu/current --verbose --endpoints endpoints.yml
 
 run-actions:
 	python -m rasa_core_sdk.endpoint --actions actions

--- a/examples/formbot/Makefile
+++ b/examples/formbot/Makefile
@@ -15,10 +15,10 @@ train-core:
 	python -m rasa.core.train -s data/stories.md -d domain.yml -o models/dialogue --debug
 
 run-core:
-	python -m rasa.core.run --core models/dialogue --nlu models/nlu/current --verbose --endpoints endpoints.yml
+	python -m rasa.core.run --core models/dialogue --verbose --endpoints endpoints.yml
 
 run-actions:
-	python -m rasa.core_sdk.endpoint --actions actions
+	python -m rasa_core_sdk.endpoint --actions actions
 
 run:
 	make run-actions&
@@ -31,4 +31,7 @@ visualize:
 	python -m rasa.core.visualize -s data/stories.md -d domain.yml -o story_graph.html
 
 train-nlu:
-	python -m rasa_nlu.train -c config.yml --fixed_model_name current --data data/nlu.md -o models --project nlu --verbose
+	python -m rasa.nlu.train -c config.yml --fixed_model_name current --data data/nlu.md -o models --project nlu --verbose
+
+evaluate-core:
+	python -m rasa.core.test --core models/dialogue -s data/stories.md --fail_on_prediction_errors

--- a/examples/moodbot/Makefile
+++ b/examples/moodbot/Makefile
@@ -11,7 +11,7 @@ help:
 	@echo "        Show your stories as a graph."
 
 train-nlu:
-	python -m rasa_nlu.train -c config.yml --fixed_model_name current \
+	python -m rasa.nlu.train -c config.yml --fixed_model_name current \
 	       --data ./data/nlu.md --path models/ --project nlu
 
 train-core:
@@ -45,7 +45,7 @@ run-cmdline:
 	python -m rasa.core.run -d models/dialogue -u models/nlu/current
 
 evaluate-nlu:
-	python -m rasa_nlu.evaluate  --model models/nlu/current --data ./data/nlu.md
+	python -m rasa.nlu.test  --model models/nlu/current --data ./data/nlu.md
 
 visualize:
 	python -m rasa.core.visualize -s data/stories.md -d domain.yml -o story_graph.html

--- a/rasa/core/policies/form_policy.py
+++ b/rasa/core/policies/form_policy.py
@@ -79,6 +79,28 @@ class FormPolicy(MemoizationPolicy):
         # modify the states
         return self._recall_states(self._modified_states(states))
 
+    def state_is_unhappy(self, tracker, domain):
+        # since it is assumed that training stories contain
+        # only unhappy paths, notify the form that
+        # it should not be validated if predicted by other policy
+        tracker_as_states = self.featurizer.prediction_states(
+            [tracker], domain)
+        states = tracker_as_states[0]
+
+        memorized_form = self.recall(states, tracker, domain)
+
+        state_is_unhappy = (
+            memorized_form is not None and
+            memorized_form == tracker.active_form.get('name')
+        )
+
+        if state_is_unhappy:
+            logger.debug("There is a memorized tracker state {}, "
+                         "added `FormValidation(False)` event"
+                         "".format(self._modified_states(states)))
+
+        return state_is_unhappy
+
     def predict_action_probabilities(self,
                                      tracker: DialogueStateTracker,
                                      domain: Domain) -> List[float]:
@@ -92,18 +114,7 @@ class FormPolicy(MemoizationPolicy):
                 # predict form action after user utterance
 
                 if tracker.active_form.get('rejected'):
-                    # since it is assumed that training stories contain
-                    # only unhappy paths, notify the form that
-                    # it should not be validated if predicted by other policy
-                    tracker_as_states = self.featurizer.prediction_states(
-                        [tracker], domain)
-                    states = tracker_as_states[0]
-                    memorized_form = self.recall(states, tracker, domain)
-
-                    if memorized_form == tracker.active_form['name']:
-                        logger.debug("There is a memorized tracker state {}, "
-                                     "added `FormValidation(False)` event"
-                                     "".format(self._modified_states(states)))
+                    if self.state_is_unhappy(tracker, domain):
                         tracker.update(FormValidation(False))
                         return result
 

--- a/rasa/core/test.py
+++ b/rasa/core/test.py
@@ -292,8 +292,7 @@ def _emulate_form_rejection(processor, partial_tracker):
             if isinstance(p, FormPolicy):
                 # emulate form rejection
                 partial_tracker.update(ActionExecutionRejected(
-                    partial_tracker.active_form["name"]
-                ))
+                    partial_tracker.active_form["name"]))
                 # check if unhappy path is covered by the train stories
                 if not p.state_is_unhappy(partial_tracker, processor.domain):
                     # this state is not covered by the stories
@@ -315,7 +314,8 @@ def _collect_action_executed_predictions(processor, partial_tracker, event,
         # but it might be Ok if form action is rejected
         _emulate_form_rejection(processor, partial_tracker)
         # try again
-        action, policy, confidence = processor.predict_next_action(partial_tracker)
+        action, policy, confidence = processor.predict_next_action(
+            partial_tracker)
         predicted = action.name()
 
     action_executed_eval_store.add_to_store(action_predictions=predicted,

--- a/rasa/core/test.py
+++ b/rasa/core/test.py
@@ -8,9 +8,7 @@ import warnings
 from collections import defaultdict, namedtuple
 from typing import Any, Dict, List, Optional, Text, Tuple
 
-from rasa.core.events import (ActionExecuted, ActionExecutionRejected,
-                              UserUttered)
-from rasa.core.policies.form_policy import FormPolicy
+from rasa.core.events import ActionExecuted, UserUttered
 
 if typing.TYPE_CHECKING:
     from rasa.core.agent import Agent
@@ -287,6 +285,9 @@ def _collect_user_uttered_predictions(event,
 
 
 def _emulate_form_rejection(processor, partial_tracker):
+    from rasa.core.policies.form_policy import FormPolicy
+    from rasa.core.events import ActionExecutionRejected
+
     if partial_tracker.active_form.get("name"):
         for p in processor.policy_ensemble.policies:
             if isinstance(p, FormPolicy):
@@ -302,6 +303,8 @@ def _emulate_form_rejection(processor, partial_tracker):
 
 def _collect_action_executed_predictions(processor, partial_tracker, event,
                                          fail_on_prediction_errors):
+    from rasa.core.policies.form_policy import FormPolicy
+
     action_executed_eval_store = EvaluationStore()
 
     gold = event.action_name

--- a/rasa/core/test.py
+++ b/rasa/core/test.py
@@ -8,7 +8,9 @@ import warnings
 from collections import defaultdict, namedtuple
 from typing import Any, Dict, List, Optional, Text, Tuple
 
-from rasa.core.events import ActionExecuted, UserUttered
+from rasa.core.events import (ActionExecuted, ActionExecutionRejected,
+                              UserUttered)
+from rasa.core.policies.form_policy import FormPolicy
 
 if typing.TYPE_CHECKING:
     from rasa.core.agent import Agent
@@ -284,14 +286,37 @@ def _collect_user_uttered_predictions(event,
     return user_uttered_eval_store
 
 
+def _emulate_form_rejection(processor, partial_tracker):
+    if partial_tracker.active_form.get("name"):
+        for p in processor.policy_ensemble.policies:
+            if isinstance(p, FormPolicy):
+                # emulate form rejection
+                partial_tracker.update(ActionExecutionRejected(
+                    partial_tracker.active_form["name"]
+                ))
+                # check if unhappy path is covered by the train stories
+                if not p.state_is_unhappy(partial_tracker, processor.domain):
+                    # this state is not covered by the stories
+                    del partial_tracker.events[-1]
+                    partial_tracker.active_form['rejected'] = False
+
+
 def _collect_action_executed_predictions(processor, partial_tracker, event,
                                          fail_on_prediction_errors):
     action_executed_eval_store = EvaluationStore()
 
-    action, policy, confidence = processor.predict_next_action(partial_tracker)
-
-    predicted = action.name()
     gold = event.action_name
+
+    action, policy, confidence = processor.predict_next_action(partial_tracker)
+    predicted = action.name()
+
+    if predicted != gold and FormPolicy.__name__ in policy:
+        # FormPolicy predicted wrong action
+        # but it might be Ok if form action is rejected
+        _emulate_form_rejection(processor, partial_tracker)
+        # try again
+        action, policy, confidence = processor.predict_next_action(partial_tracker)
+        predicted = action.name()
 
     action_executed_eval_store.add_to_store(action_predictions=predicted,
                                             action_targets=gold)
@@ -302,9 +327,15 @@ def _collect_action_executed_predictions(processor, partial_tracker, event,
                                                       event.confidence,
                                                       event.timestamp))
         if fail_on_prediction_errors:
-            raise ValueError(
-                "Model predicted a wrong action. Failed Story: "
-                "\n\n{}".format(partial_tracker.export_stories()))
+            error_msg = ("Model predicted a wrong action. Failed Story: "
+                         "\n\n{}".format(partial_tracker.export_stories()))
+            if FormPolicy.__name__ in policy:
+                error_msg += ("FormAction is not run during "
+                              "evaluation therefore it is impossible to know "
+                              "if validation failed or this story is wrong. "
+                              "If the story is correct, add it to the "
+                              "training stories and retrain.")
+            raise ValueError(error_msg)
     else:
         partial_tracker.update(event)
 


### PR DESCRIPTION
**Proposed changes**:
-  FormAction is not run, so we add `ActionExecutionRejected` event if form action is predicted, but not expected and if "unhappy" intent is remembered by FormPolicy
- fixes #2792 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog