### PR TITLE
Updating requirements-dev filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ To build & edit the docs, first install all necessary dependencies:
 
 ```
 brew install sphinx
-pip3 install -r dev-requirements.txt
+pip3 install -r requirements-dev.txt
 ```
 
 After the installation has finished, you can run and view the documentation


### PR DESCRIPTION
The dependencies txt file "requirements-dev" appears to be named "dev-requirements" by mistake which results in pip package installation error.

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [Y] made PR ready for code review
- [ ] added some tests for the functionality
- [Y] updated the documentation
- [ ] updated the changelog
