### PR TITLE
add info about duckling url env var to docs

### DIFF
--- a/docs/nlu/components.rst
+++ b/docs/nlu/components.rst
@@ -706,5 +706,9 @@ DucklingHTTPExtractor
           # needed to calculate dates from relative expressions like "tomorrow"
           timezone: "Europe/Berlin"
 
+    In addition to setting the default ``url`` of your duckling server in the
+    configuration, you can also change the url of your duckling server (without
+    needing to re-train your model) by setting the ``RASA_DUCKLING_HTTP_URL``
+    environment variable.
 
 .. include:: feedback.inc


### PR DESCRIPTION
**Proposed changes**:
- we already have this option to set a duckling url environment variable (to be able to change your duckling url for the same trained model in a different environment, for example) -- this puts the information in the docs. See #3216 

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
